### PR TITLE
Set contract licenses to MIT

### DIFF
--- a/contracts/evm/package.json
+++ b/contracts/evm/package.json
@@ -11,7 +11,7 @@
     "build-bls-utils": "cd test/ffi/bls-utils && cargo build"
   },
   "author": "NethermindEth",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "dependencies": {
     "@eth-optimism/contracts": "^0.6.0"
   }

--- a/contracts/evm/script/SFFLDeployer.s.sol
+++ b/contracts/evm/script/SFFLDeployer.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
 import {ProxyAdmin, TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";

--- a/contracts/evm/src/base/SFFLRegistryBase.sol
+++ b/contracts/evm/src/base/SFFLRegistryBase.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {Lib_AddressResolver} from "@eth-optimism/contracts/libraries/resolver/Lib_AddressResolver.sol";

--- a/contracts/evm/src/base/message/StateRootUpdate.sol
+++ b/contracts/evm/src/base/message/StateRootUpdate.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 /**

--- a/contracts/evm/src/eth/SFFLOperatorSetUpdateRegistry.sol
+++ b/contracts/evm/src/eth/SFFLOperatorSetUpdateRegistry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";

--- a/contracts/evm/src/eth/SFFLRegistryCoordinator.sol
+++ b/contracts/evm/src/eth/SFFLRegistryCoordinator.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity =0.8.12;
 
 import {IPauserRegistry} from "eigenlayer-contracts/src/contracts/interfaces/IPauserRegistry.sol";

--- a/contracts/evm/src/eth/SFFLServiceManager.sol
+++ b/contracts/evm/src/eth/SFFLServiceManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {ServiceManagerBase} from "eigenlayer-middleware/src/ServiceManagerBase.sol";

--- a/contracts/evm/src/eth/SFFLTaskManager.sol
+++ b/contracts/evm/src/eth/SFFLTaskManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {Initializable} from "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";

--- a/contracts/evm/src/eth/task/Checkpoint.sol
+++ b/contracts/evm/src/eth/task/Checkpoint.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 /**

--- a/contracts/evm/src/rollup/SFFLRegistryRollup.sol
+++ b/contracts/evm/src/rollup/SFFLRegistryRollup.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/evm/src/rollup/message/OperatorSetUpdate.sol
+++ b/contracts/evm/src/rollup/message/OperatorSetUpdate.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {Operators} from "../utils/Operators.sol";

--- a/contracts/evm/src/rollup/utils/Operators.sol
+++ b/contracts/evm/src/rollup/utils/Operators.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {BN254} from "eigenlayer-middleware/src/libraries/BN254.sol";

--- a/contracts/evm/test/SFFLRegistryBase.t.sol
+++ b/contracts/evm/test/SFFLRegistryBase.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {Test, console2} from "forge-std/Test.sol";

--- a/contracts/evm/test/SFFLRegistryRollup.t.sol
+++ b/contracts/evm/test/SFFLRegistryRollup.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {BN254} from "eigenlayer-middleware/src/libraries/BN254.sol";

--- a/contracts/evm/test/SFFLServiceManager.t.sol
+++ b/contracts/evm/test/SFFLServiceManager.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {Test, console2} from "forge-std/Test.sol";

--- a/contracts/evm/test/SFFLTaskManager.t.sol
+++ b/contracts/evm/test/SFFLTaskManager.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {Test, console2} from "forge-std/Test.sol";

--- a/contracts/evm/test/ffi/SFFLTaskManagerFFI.t.sol
+++ b/contracts/evm/test/ffi/SFFLTaskManagerFFI.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {Test, console2} from "forge-std/Test.sol";

--- a/contracts/evm/test/utils/BLSUtilsFFI.sol
+++ b/contracts/evm/test/utils/BLSUtilsFFI.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity =0.8.12;
 
 import {Test} from "forge-std/Test.sol";

--- a/contracts/evm/test/utils/TestUtils.sol
+++ b/contracts/evm/test/utils/TestUtils.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
 import {Test} from "forge-std/Test.sol";


### PR DESCRIPTION
Just a quick replace on the previously unlicensed contracts for the MIT migration.