### PR TITLE
Add checkpoint message fetching

### DIFF
--- a/aggregator/database/database.go
+++ b/aggregator/database/database.go
@@ -221,7 +221,7 @@ func (d *Database) FetchCheckpointMessages(fromTimestamp uint64, toTimestamp uin
 		Model(&models.StateRootUpdateMessage{}).
 		Where("timestamp >= ?", fromTimestamp).
 		Where("timestamp <= ?", toTimestamp).
-		First(&stateRootUpdates)
+		Find(&stateRootUpdates)
 	if tx.Error != nil {
 		return tx.Error
 	}
@@ -233,7 +233,7 @@ func (d *Database) FetchCheckpointMessages(fromTimestamp uint64, toTimestamp uin
 		Model(&models.OperatorSetUpdateMessage{}).
 		Where("timestamp >= ?", fromTimestamp).
 		Where("timestamp <= ?", toTimestamp).
-		First(&operatorSetUpdates)
+		Find(&operatorSetUpdates)
 	if tx.Error != nil {
 		return tx.Error
 	}

--- a/aggregator/database/database_test.go
+++ b/aggregator/database/database_test.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/NethermindEth/near-sffl/aggregator/database"
-	"github.com/NethermindEth/near-sffl/aggregator/types"
+	aggtypes "github.com/NethermindEth/near-sffl/aggregator/types"
 	registryrollup "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLRegistryRollup"
 	servicemanager "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLServiceManager"
 	"github.com/NethermindEth/near-sffl/core"
@@ -60,7 +60,7 @@ func TestFetchUnknownStateRootUpdateAggregation(t *testing.T) {
 	db, err := database.NewDatabase("")
 	assert.Nil(t, err)
 
-	var entry types.MessageBlsAggregationServiceResponse
+	var entry aggtypes.MessageBlsAggregationServiceResponse
 
 	err = db.FetchStateRootUpdateAggregation(1, 2, &entry)
 	assert.NotNil(t, err)
@@ -86,14 +86,14 @@ func TestStoreAndFetchStateRootUpdateAggregation(t *testing.T) {
 	msgDigest, err := core.GetStateRootUpdateMessageDigest(&msg)
 	assert.Nil(t, err)
 
-	value := types.MessageBlsAggregationServiceResponse{
+	value := aggtypes.MessageBlsAggregationServiceResponse{
 		MessageDigest: msgDigest,
 	}
 
 	err = db.StoreStateRootUpdateAggregation(msg, value)
 	assert.Nil(t, err)
 
-	var entry types.MessageBlsAggregationServiceResponse
+	var entry aggtypes.MessageBlsAggregationServiceResponse
 
 	err = db.FetchStateRootUpdateAggregation(msg.RollupId, msg.BlockHeight, &entry)
 	assert.Nil(t, err)
@@ -147,7 +147,7 @@ func TestFetchUnknownOperatorSetUpdateAggregation(t *testing.T) {
 	db, err := database.NewDatabase("")
 	assert.Nil(t, err)
 
-	var entry types.MessageBlsAggregationServiceResponse
+	var entry aggtypes.MessageBlsAggregationServiceResponse
 
 	err = db.FetchOperatorSetUpdateAggregation(1, &entry)
 	assert.NotNil(t, err)
@@ -174,14 +174,14 @@ func TestStoreAndFetchOperatorSetUpdateAggregation(t *testing.T) {
 	msgDigest, err := core.GetOperatorSetUpdateMessageDigest(&msg)
 	assert.Nil(t, err)
 
-	value := types.MessageBlsAggregationServiceResponse{
+	value := aggtypes.MessageBlsAggregationServiceResponse{
 		MessageDigest: msgDigest,
 	}
 
 	err = db.StoreOperatorSetUpdateAggregation(msg, value)
 	assert.Nil(t, err)
 
-	var entry types.MessageBlsAggregationServiceResponse
+	var entry aggtypes.MessageBlsAggregationServiceResponse
 
 	err = db.FetchOperatorSetUpdateAggregation(msg.Id, &entry)
 	assert.Nil(t, err)

--- a/aggregator/database/database_test.go
+++ b/aggregator/database/database_test.go
@@ -12,6 +12,7 @@ import (
 	registryrollup "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLRegistryRollup"
 	servicemanager "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLServiceManager"
 	"github.com/NethermindEth/near-sffl/core"
+	coretypes "github.com/NethermindEth/near-sffl/core/types"
 	"github.com/NethermindEth/near-sffl/tests"
 )
 
@@ -187,4 +188,132 @@ func TestStoreAndFetchOperatorSetUpdateAggregation(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, entry, entry)
+}
+
+func TestFetchCheckpointMessages(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	db, err := database.NewDatabase("")
+	assert.Nil(t, err)
+
+	msg1 := servicemanager.StateRootUpdateMessage{
+		RollupId:    1,
+		BlockHeight: 1,
+		Timestamp:   0,
+		StateRoot:   tests.Keccak256(4),
+	}
+
+	msgDigest1, err := core.GetStateRootUpdateMessageDigest(&msg1)
+	assert.Nil(t, err)
+
+	aggregation1 := aggtypes.MessageBlsAggregationServiceResponse{
+		MessageDigest: msgDigest1,
+	}
+
+	msg2 := servicemanager.StateRootUpdateMessage{
+		RollupId:    1,
+		BlockHeight: 2,
+		Timestamp:   1,
+		StateRoot:   tests.Keccak256(4),
+	}
+
+	msgDigest2, err := core.GetStateRootUpdateMessageDigest(&msg2)
+	assert.Nil(t, err)
+
+	aggregation2 := aggtypes.MessageBlsAggregationServiceResponse{
+		MessageDigest: msgDigest2,
+	}
+
+	msg3 := registryrollup.OperatorSetUpdateMessage{
+		Id:        1,
+		Timestamp: 2,
+		Operators: []registryrollup.OperatorsOperator{
+			{Pubkey: registryrollup.BN254G1Point{X: big.NewInt(3), Y: big.NewInt(4)}, Weight: big.NewInt(5)},
+		},
+	}
+
+	msgDigest3, err := core.GetOperatorSetUpdateMessageDigest(&msg3)
+	assert.Nil(t, err)
+
+	aggregation3 := aggtypes.MessageBlsAggregationServiceResponse{
+		MessageDigest: msgDigest3,
+	}
+
+	msg4 := registryrollup.OperatorSetUpdateMessage{
+		Id:        2,
+		Timestamp: 3,
+		Operators: []registryrollup.OperatorsOperator{
+			{Pubkey: registryrollup.BN254G1Point{X: big.NewInt(3), Y: big.NewInt(4)}, Weight: big.NewInt(5)},
+		},
+	}
+
+	msgDigest4, err := core.GetOperatorSetUpdateMessageDigest(&msg4)
+	assert.Nil(t, err)
+
+	aggregation4 := aggtypes.MessageBlsAggregationServiceResponse{
+		MessageDigest: msgDigest4,
+	}
+
+	err = db.StoreStateRootUpdate(msg1)
+	assert.Nil(t, err)
+
+	err = db.StoreStateRootUpdateAggregation(msg1, aggregation1)
+	assert.Nil(t, err)
+
+	err = db.StoreStateRootUpdate(msg2)
+	assert.Nil(t, err)
+
+	err = db.StoreStateRootUpdateAggregation(msg2, aggregation2)
+	assert.Nil(t, err)
+
+	err = db.StoreOperatorSetUpdate(msg3)
+	assert.Nil(t, err)
+
+	err = db.StoreOperatorSetUpdateAggregation(msg3, aggregation3)
+	assert.Nil(t, err)
+
+	err = db.StoreOperatorSetUpdate(msg4)
+	assert.Nil(t, err)
+
+	err = db.StoreOperatorSetUpdateAggregation(msg4, aggregation4)
+	assert.Nil(t, err)
+
+	var result coretypes.CheckpointMessages
+
+	err = db.FetchCheckpointMessages(0, 3, &result)
+	assert.Nil(t, err)
+	assert.Equal(t, result, coretypes.CheckpointMessages{
+		StateRootUpdateMessages:              []servicemanager.StateRootUpdateMessage{msg1, msg2},
+		StateRootUpdateMessageAggregations:   []aggtypes.MessageBlsAggregationServiceResponse{aggregation1, aggregation2},
+		OperatorSetUpdateMessages:            []registryrollup.OperatorSetUpdateMessage{msg3, msg4},
+		OperatorSetUpdateMessageAggregations: []aggtypes.MessageBlsAggregationServiceResponse{aggregation3, aggregation4},
+	})
+
+	err = db.FetchCheckpointMessages(1, 3, &result)
+	assert.Nil(t, err)
+	assert.Equal(t, result, coretypes.CheckpointMessages{
+		StateRootUpdateMessages:              []servicemanager.StateRootUpdateMessage{msg2},
+		StateRootUpdateMessageAggregations:   []aggtypes.MessageBlsAggregationServiceResponse{aggregation2},
+		OperatorSetUpdateMessages:            []registryrollup.OperatorSetUpdateMessage{msg3, msg4},
+		OperatorSetUpdateMessageAggregations: []aggtypes.MessageBlsAggregationServiceResponse{aggregation3, aggregation4},
+	})
+
+	err = db.FetchCheckpointMessages(1, 2, &result)
+	assert.Nil(t, err)
+	assert.Equal(t, result, coretypes.CheckpointMessages{
+		StateRootUpdateMessages:              []servicemanager.StateRootUpdateMessage{msg2},
+		StateRootUpdateMessageAggregations:   []aggtypes.MessageBlsAggregationServiceResponse{aggregation2},
+		OperatorSetUpdateMessages:            []registryrollup.OperatorSetUpdateMessage{msg3},
+		OperatorSetUpdateMessageAggregations: []aggtypes.MessageBlsAggregationServiceResponse{aggregation3},
+	})
+
+	err = db.FetchCheckpointMessages(4, 10, &result)
+	assert.Nil(t, err)
+	assert.Equal(t, result, coretypes.CheckpointMessages{
+		StateRootUpdateMessages:              []servicemanager.StateRootUpdateMessage{},
+		StateRootUpdateMessageAggregations:   []aggtypes.MessageBlsAggregationServiceResponse{},
+		OperatorSetUpdateMessages:            []registryrollup.OperatorSetUpdateMessage{},
+		OperatorSetUpdateMessageAggregations: []aggtypes.MessageBlsAggregationServiceResponse{},
+	})
 }

--- a/aggregator/database/mocks/database.go
+++ b/aggregator/database/mocks/database.go
@@ -14,6 +14,7 @@ import (
 	types "github.com/NethermindEth/near-sffl/aggregator/types"
 	contractSFFLRegistryRollup "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLRegistryRollup"
 	contractSFFLServiceManager "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLServiceManager"
+	types0 "github.com/NethermindEth/near-sffl/core/types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -52,6 +53,20 @@ func (m *MockDatabaser) Close() error {
 func (mr *MockDatabaserMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDatabaser)(nil).Close))
+}
+
+// FetchCheckpointMessages mocks base method.
+func (m *MockDatabaser) FetchCheckpointMessages(arg0, arg1 uint64, arg2 *types0.CheckpointMessages) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchCheckpointMessages", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FetchCheckpointMessages indicates an expected call of FetchCheckpointMessages.
+func (mr *MockDatabaserMockRecorder) FetchCheckpointMessages(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchCheckpointMessages", reflect.TypeOf((*MockDatabaser)(nil).FetchCheckpointMessages), arg0, arg1, arg2)
 }
 
 // FetchOperatorSetUpdate mocks base method.

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -11,10 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
-	"github.com/NethermindEth/near-sffl/aggregator/types"
+	aggtypes "github.com/NethermindEth/near-sffl/aggregator/types"
 	registryrollup "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLRegistryRollup"
 	servicemanager "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLServiceManager"
 	"github.com/NethermindEth/near-sffl/core"
+	"github.com/NethermindEth/near-sffl/core/types"
 	coretypes "github.com/NethermindEth/near-sffl/core/types"
 )
 
@@ -36,7 +37,7 @@ func TestGetStateRootUpdateAggregation(t *testing.T) {
 	msgDigest, err := core.GetStateRootUpdateMessageDigest(&msg)
 	assert.Nil(t, err)
 
-	aggregation := types.MessageBlsAggregationServiceResponse{
+	aggregation := aggtypes.MessageBlsAggregationServiceResponse{
 		MessageDigest: msgDigest,
 	}
 
@@ -53,7 +54,7 @@ func TestGetStateRootUpdateAggregation(t *testing.T) {
 	)
 
 	mockDb.EXPECT().FetchStateRootUpdateAggregation(msg.RollupId, msg.BlockHeight, gomock.Any()).DoAndReturn(
-		func(rollupId coretypes.RollupId, blockHeight uint64, aggPtr *types.MessageBlsAggregationServiceResponse) error {
+		func(rollupId coretypes.RollupId, blockHeight uint64, aggPtr *aggtypes.MessageBlsAggregationServiceResponse) error {
 			if rollupId != msg.RollupId || blockHeight != msg.BlockHeight {
 				return errors.New("Unexpected args")
 			}
@@ -109,7 +110,7 @@ func TestGetOperatorSetUpdateAggregation(t *testing.T) {
 	msgDigest, err := core.GetOperatorSetUpdateMessageDigest(&msg)
 	assert.Nil(t, err)
 
-	aggregation := types.MessageBlsAggregationServiceResponse{
+	aggregation := aggtypes.MessageBlsAggregationServiceResponse{
 		MessageDigest: msgDigest,
 	}
 
@@ -126,7 +127,7 @@ func TestGetOperatorSetUpdateAggregation(t *testing.T) {
 	)
 
 	mockDb.EXPECT().FetchOperatorSetUpdateAggregation(msg.Id, gomock.Any()).DoAndReturn(
-		func(id uint64, aggPtr *types.MessageBlsAggregationServiceResponse) error {
+		func(id uint64, aggPtr *aggtypes.MessageBlsAggregationServiceResponse) error {
 			if id != msg.Id {
 				return errors.New("Unexpected args")
 			}
@@ -153,6 +154,84 @@ func TestGetOperatorSetUpdateAggregation(t *testing.T) {
 		Aggregation: aggregation,
 	}
 	var body GetOperatorSetUpdateAggregationResponse
+
+	assert.Equal(t, recorder.Code, http.StatusOK)
+
+	if recorder.Code != http.StatusOK {
+		fmt.Printf("HTTP Error: %s", recorder.Body.Bytes())
+	}
+
+	err = json.Unmarshal(recorder.Body.Bytes(), &body)
+	assert.Nil(t, err)
+
+	assert.Equal(t, body, expectedBody)
+}
+
+func TestGetCheckpointMessages(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	aggregator, _, _, _, _, _, mockDb, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
+	assert.Nil(t, err)
+
+	go aggregator.startRestServer()
+
+	msg := servicemanager.StateRootUpdateMessage{
+		RollupId:    1,
+		BlockHeight: 2,
+		Timestamp:   3,
+	}
+	msgDigest, err := core.GetStateRootUpdateMessageDigest(&msg)
+	assert.Nil(t, err)
+
+	aggregation := aggtypes.MessageBlsAggregationServiceResponse{
+		MessageDigest: msgDigest,
+	}
+
+	msg2 := registryrollup.OperatorSetUpdateMessage{
+		Id:        1,
+		Timestamp: 2,
+	}
+	msgDigest2, err := core.GetOperatorSetUpdateMessageDigest(&msg2)
+	assert.Nil(t, err)
+
+	aggregation2 := aggtypes.MessageBlsAggregationServiceResponse{
+		MessageDigest: msgDigest2,
+	}
+
+	mockDb.EXPECT().FetchCheckpointMessages(uint64(0), uint64(3), gomock.Any()).DoAndReturn(
+		func(fromTimestamp uint64, toTimestamp uint64, result *types.CheckpointMessages) error {
+			*result = types.CheckpointMessages{
+				StateRootUpdateMessages:              []servicemanager.StateRootUpdateMessage{msg},
+				StateRootUpdateMessageAggregations:   []aggtypes.MessageBlsAggregationServiceResponse{aggregation},
+				OperatorSetUpdateMessages:            []registryrollup.OperatorSetUpdateMessage{msg2},
+				OperatorSetUpdateMessageAggregations: []aggtypes.MessageBlsAggregationServiceResponse{aggregation2},
+			}
+
+			return nil
+		},
+	)
+
+	req, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf("/checkpoint/messages?fromTimestamp=%d&toTimestamp=%d", 0, 3),
+		nil,
+	)
+	assert.Nil(t, err)
+
+	recorder := httptest.NewRecorder()
+
+	aggregator.handleGetCheckpointMessages(recorder, req)
+
+	expectedBody := GetCheckpointMessagesResponse{
+		CheckpointMessages: types.CheckpointMessages{
+			StateRootUpdateMessages:              []servicemanager.StateRootUpdateMessage{msg},
+			StateRootUpdateMessageAggregations:   []aggtypes.MessageBlsAggregationServiceResponse{aggregation},
+			OperatorSetUpdateMessages:            []registryrollup.OperatorSetUpdateMessage{msg2},
+			OperatorSetUpdateMessageAggregations: []aggtypes.MessageBlsAggregationServiceResponse{aggregation2},
+		},
+	}
+	var body GetCheckpointMessagesResponse
 
 	assert.Equal(t, recorder.Code, http.StatusOK)
 

--- a/aggregator/types/types.go
+++ b/aggregator/types/types.go
@@ -6,8 +6,6 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	sdktypes "github.com/Layr-Labs/eigensdk-go/types"
 	"github.com/ethereum/go-ethereum/common"
-
-	coretypes "github.com/NethermindEth/near-sffl/core/types"
 )
 
 // TODO: Hardcoded for now
@@ -27,7 +25,7 @@ type OperatorInfo struct {
 type MessageBlsAggregationServiceResponse struct {
 	Err                          error
 	EthBlockNumber               uint64
-	MessageDigest                coretypes.MessageDigest
+	MessageDigest                [32]byte // TODO: solve this when integrating canonical messages
 	NonSignersPubkeysG1          []*bls.G1Point
 	QuorumApksG1                 []*bls.G1Point
 	SignersApkG2                 *bls.G2Point

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -3,6 +3,8 @@ package types
 import (
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 
+	aggtypes "github.com/NethermindEth/near-sffl/aggregator/types"
+
 	registryrollup "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLRegistryRollup"
 	servicemanager "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLServiceManager"
 	taskmanager "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLTaskManager"
@@ -32,4 +34,11 @@ type SignedOperatorSetUpdateMessage struct {
 	Message      registryrollup.OperatorSetUpdateMessage
 	BlsSignature bls.Signature
 	OperatorId   bls.OperatorId
+}
+
+type CheckpointMessages struct {
+	StateRootUpdateMessages              []servicemanager.StateRootUpdateMessage
+	StateRootUpdateMessageAggregations   []aggtypes.MessageBlsAggregationServiceResponse
+	OperatorSetUpdateMessages            []registryrollup.OperatorSetUpdateMessage
+	OperatorSetUpdateMessageAggregations []aggtypes.MessageBlsAggregationServiceResponse
 }


### PR DESCRIPTION
This PR adds support for fetching checkpoint messages (i.e. getting messages and aggregations filtering by timestamp) and adds a `/checkpoint/messages` `GET` route that fetches this data and responds to it.

This is also ready, but on draft until #48 is merged - then it will be updated. Anyway, feel free to review @taco-paco 