### PR TITLE
Fix integration tests on Mac

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -307,9 +307,9 @@ func (agg *Aggregator) handleStateRootUpdateReachedQuorum(blsAggServiceResp type
 	agg.stateRootUpdatesLock.RUnlock()
 
 	defer func() {
-		agg.stateRootUpdatesLock.RLock()
+		agg.stateRootUpdatesLock.Lock()
 		delete(agg.stateRootUpdates, blsAggServiceResp.MessageDigest)
-		agg.stateRootUpdatesLock.RUnlock()
+		agg.stateRootUpdatesLock.Unlock()
 	}()
 
 	if !ok {
@@ -332,7 +332,6 @@ func (agg *Aggregator) handleStateRootUpdateReachedQuorum(blsAggServiceResp type
 		agg.logger.Error("Aggregator could not store message aggregation")
 		return
 	}
-
 }
 
 func (agg *Aggregator) handleOperatorSetUpdateReachedQuorum(ctx context.Context, blsAggServiceResp types.MessageBlsAggregationServiceResponse) {
@@ -341,9 +340,9 @@ func (agg *Aggregator) handleOperatorSetUpdateReachedQuorum(ctx context.Context,
 	agg.operatorSetUpdatesLock.RUnlock()
 
 	defer func() {
-		agg.operatorSetUpdatesLock.RLock()
+		agg.operatorSetUpdatesLock.Lock()
 		delete(agg.operatorSetUpdates, blsAggServiceResp.MessageDigest)
-		agg.operatorSetUpdatesLock.RUnlock()
+		agg.operatorSetUpdatesLock.Unlock()
 	}()
 
 	if !ok {

--- a/aggregator/rollup_broadcaster.go
+++ b/aggregator/rollup_broadcaster.go
@@ -72,6 +72,7 @@ func (w *RollupWriter) UpdateOperatorSet(ctx context.Context, message registryro
 
 		// TODO: queue in case message.id > nextOperatorUpdateId
 		if message.Id != nextOperatorUpdateId {
+			w.logger.Warn("MessageId didn't match nextOperatorUpdateId", "id", message.Id, "nextOperatorUpdateId", nextOperatorUpdateId)
 			return nil
 		}
 
@@ -93,6 +94,8 @@ func (w *RollupWriter) UpdateOperatorSet(ctx context.Context, message registryro
 	for i := 0; i < NUM_OF_RETRIES; i++ {
 		err = operation()
 		if err == nil {
+			w.logger.Info("Rollup Operator set updated")
+
 			return nil
 		} else {
 			// TODO: return on some tx errors

--- a/config-files/aggregator-docker-compose.yaml
+++ b/config-files/aggregator-docker-compose.yaml
@@ -4,7 +4,7 @@ eth_rpc_url: http://mainnet-anvil:8545
 eth_ws_url: ws://mainnet-anvil:8545
 # address which the aggregator listens on for operator signed messages
 aggregator_server_ip_port_address: 0.0.0.0:8090
-aggregator_rest_server_ip_port_address: localhost:5000
+aggregator_rest_server_ip_port_address: localhost:5001
 aggregator_database_path: ""
 rollup_ids_to_rpc_urls:
   2: ws://rollup0-anvil:8546

--- a/config-files/aggregator.yaml
+++ b/config-files/aggregator.yaml
@@ -4,7 +4,7 @@ eth_rpc_url: http://localhost:8545
 eth_ws_url: ws://localhost:8545
 # address which the aggregator listens on for operator signed messages
 aggregator_server_ip_port_address: localhost:8090
-aggregator_rest_server_ip_port_address: localhost:5000
+aggregator_rest_server_ip_port_address: localhost:5001
 aggregator_database_path: ./aggregator.db
 rollup_ids_to_rpc_urls:
   2: ws://localhost:8546

--- a/operator/attestor/attestor.go
+++ b/operator/attestor/attestor.go
@@ -153,7 +153,8 @@ func (attestor *Attestor) processMQBlocks(ctx context.Context) {
 			go func(mqBlock consumer.BlockData) {
 				select {
 				case <-time.After(MQ_REBROADCAST_DELAY):
-					attestor.notifier.Notify(mqBlock.RollupId, mqBlock)
+					err := attestor.notifier.Notify(mqBlock.RollupId, mqBlock)
+					attestor.logger.Warn("Renotify", "err", err)
 					return
 
 				case <-ctx.Done():

--- a/operator/attestor/attestor.go
+++ b/operator/attestor/attestor.go
@@ -202,7 +202,7 @@ func (attestor *Attestor) processRollupHeaders(rollupId uint32, headersC chan *e
 
 		case header, ok := <-headersC:
 			if !ok {
-				continue
+				return
 			}
 
 			go attestor.processHeader(rollupId, header, ctx)

--- a/operator/consumer/consumer.go
+++ b/operator/consumer/consumer.go
@@ -203,7 +203,7 @@ func (consumer *Consumer) setupChannel(conn *rmq.Connection, ctx context.Context
 			return err
 		}
 
-		err = listener.Add(rollupId, rollupDataC, ctx)
+		err = listener.Add(ctx, rollupId, rollupDataC)
 		if err != nil {
 			return err
 		}

--- a/operator/consumer/queues_listener.go
+++ b/operator/consumer/queues_listener.go
@@ -33,7 +33,7 @@ func NewQueuesListener(receivedBlocksC chan<- BlockData, logger logging.Logger) 
 	return listener
 }
 
-func (l *QueuesListener) Add(rollupId uint32, rollupDataC <-chan rmq.Delivery, ctx context.Context) error {
+func (l *QueuesListener) Add(ctx context.Context, rollupId uint32, rollupDataC <-chan rmq.Delivery) error {
 	l.queueDeliveryMutex.Lock()
 	defer l.queueDeliveryMutex.Unlock()
 
@@ -42,7 +42,7 @@ func (l *QueuesListener) Add(rollupId uint32, rollupDataC <-chan rmq.Delivery, c
 	}
 	l.queueDeliveryCs[rollupId] = rollupDataC
 
-	go l.listen(rollupId, rollupDataC, ctx)
+	go l.listen(ctx, rollupId, rollupDataC)
 
 	return nil
 }
@@ -53,7 +53,7 @@ func (l *QueuesListener) Remove(rollupId uint32) {
 	l.queueDeliveryMutex.Unlock()
 }
 
-func (l *QueuesListener) listen(rollupId uint32, rollupDataC <-chan rmq.Delivery, ctx context.Context) {
+func (l *QueuesListener) listen(ctx context.Context, rollupId uint32, rollupDataC <-chan rmq.Delivery) {
 	for {
 		select {
 		case d, ok := <-rollupDataC:

--- a/operator/consumer/queues_listener.go
+++ b/operator/consumer/queues_listener.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -15,8 +16,9 @@ var (
 )
 
 type QueuesListener struct {
-	receivedBlocksC chan<- BlockData
-	queueDeliveryCs map[uint32]<-chan rmq.Delivery
+	receivedBlocksC    chan<- BlockData
+	queueDeliveryCs    map[uint32]<-chan rmq.Delivery
+	queueDeliveryMutex sync.Mutex
 
 	logger logging.Logger
 }
@@ -31,39 +33,49 @@ func NewQueuesListener(receivedBlocksC chan<- BlockData, logger logging.Logger) 
 	return listener
 }
 
-func (listener *QueuesListener) Add(rollupId uint32, rollupDataC <-chan rmq.Delivery, ctx context.Context) error {
-	if _, exists := listener.queueDeliveryCs[rollupId]; exists {
+func (l *QueuesListener) Add(rollupId uint32, rollupDataC <-chan rmq.Delivery, ctx context.Context) error {
+	l.queueDeliveryMutex.Lock()
+	defer l.queueDeliveryMutex.Unlock()
+
+	if _, exists := l.queueDeliveryCs[rollupId]; exists {
 		return QueueExistsError
 	}
+	l.queueDeliveryCs[rollupId] = rollupDataC
 
-	listener.queueDeliveryCs[rollupId] = rollupDataC
-	go listener.listen(rollupId, rollupDataC, ctx)
+	go l.listen(rollupId, rollupDataC, ctx)
 
 	return nil
 }
 
-func (listener *QueuesListener) listen(rollupId uint32, rollupDataC <-chan rmq.Delivery, ctx context.Context) {
+func (l *QueuesListener) Remove(rollupId uint32) {
+	l.queueDeliveryMutex.Lock()
+	delete(l.queueDeliveryCs, rollupId)
+	l.queueDeliveryMutex.Unlock()
+}
+
+func (l *QueuesListener) listen(rollupId uint32, rollupDataC <-chan rmq.Delivery, ctx context.Context) {
 	for {
 		select {
 		case d, ok := <-rollupDataC:
 			if !ok {
-				listener.logger.Info("Deliveries channel close", "rollupId", rollupId)
-				break
+				l.logger.Info("Deliveries channel close", "rollupId", rollupId)
+				l.Remove(rollupId)
+				return
 			}
 
-			listener.logger.Info("New delivery", "rollupId", rollupId)
+			l.logger.Info("New delivery", "rollupId", rollupId)
 
 			var block types.Block
 			if err := rlp.DecodeBytes(d.Body, &block); err != nil {
-				listener.logger.Warn("Invalid block", "rollupId", rollupId, "err", err)
+				l.logger.Warn("Invalid block", "rollupId", rollupId, "err", err)
 				continue
 			}
 
-			listener.receivedBlocksC <- BlockData{RollupId: rollupId, Block: block}
+			l.receivedBlocksC <- BlockData{RollupId: rollupId, Block: block}
 			d.Ack(false)
 
 		case <-ctx.Done():
-			listener.logger.Info("Consumer context canceled")
+			l.logger.Info("Consumer context canceled")
 			// TODO: some closing and canceling here
 			return
 		}

--- a/operator/rpc_client.go
+++ b/operator/rpc_client.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"fmt"
 	"net/rpc"
+	"sync"
 	"time"
 
 	coretypes "github.com/NethermindEth/near-sffl/core/types"
@@ -16,24 +17,78 @@ type AggregatorRpcClienter interface {
 	SendSignedStateRootUpdateToAggregator(signedStateRootUpdateMessage *coretypes.SignedStateRootUpdateMessage)
 	SendSignedOperatorSetUpdateToAggregator(signedOperatorSetUpdateMessage *coretypes.SignedOperatorSetUpdateMessage)
 }
+
+const (
+	CheckpointType = iota
+	StateRootType
+	OperatorSetUpdateType
+)
+
+const (
+	ResendInterval = 5 * time.Second
+)
+
+type RpcMessageType struct {
+	MessageType int
+	Message     interface{}
+}
+
 type AggregatorRpcClient struct {
-	rpcClient            *rpc.Client
+	rpcClientMutex sync.Mutex
+	rpcClient      *rpc.Client
+
 	metrics              metrics.Metrics
 	logger               logging.Logger
 	aggregatorIpPortAddr string
+
+	messageDequeMutex sync.Mutex
+	messageDeque      []RpcMessageType
+
+	resendTickerMutex sync.Mutex
+	resendTicker      *time.Ticker
 }
 
 func NewAggregatorRpcClient(aggregatorIpPortAddr string, logger logging.Logger, metrics metrics.Metrics) (*AggregatorRpcClient, error) {
-	return &AggregatorRpcClient{
+	resendTicker := time.NewTicker(ResendInterval)
+
+	client := &AggregatorRpcClient{
 		// set to nil so that we can create an rpc client even if the aggregator is not running
 		rpcClient:            nil,
 		metrics:              metrics,
 		logger:               logger,
 		aggregatorIpPortAddr: aggregatorIpPortAddr,
-	}, nil
+		messageDeque:         make([]RpcMessageType, 0),
+		resendTicker:         resendTicker,
+	}
+
+	go client.onTick()
+	return client, nil
+}
+
+func (c *AggregatorRpcClient) onTick() {
+	tickerC := c.resendTicker.C
+	for {
+		// TODO(edwin): handle closed chan
+		<-tickerC
+
+		// Critically ugly section
+		{
+			c.rpcClientMutex.Lock()
+			if c.rpcClient == nil {
+				c.rpcClientMutex.Unlock()
+				continue
+			}
+
+			c.rpcClientMutex.Unlock()
+		}
+
+		c.tryResendFromDeque()
+	}
 }
 
 func (c *AggregatorRpcClient) dialAggregatorRpcClient() error {
+	c.logger.Info("rpc client is nil. Dialing aggregator rpc client")
+
 	client, err := rpc.DialHTTP("tcp", c.aggregatorIpPortAddr)
 	if err != nil {
 		return err
@@ -68,56 +123,176 @@ func (c *AggregatorRpcClient) sendRequest(sendCb func() error, maxRetries int, r
 	c.logger.Errorf("Could not send data to aggregator. Tried %d times.", maxRetries)
 }
 
+func (c *AggregatorRpcClient) InitializeClientIfNotExist() error {
+	c.rpcClientMutex.Lock()
+	defer c.rpcClientMutex.Unlock()
+
+	if c.rpcClient != nil {
+		return nil
+	}
+
+	c.logger.Info("rpc client is nil. Dialing aggregator rpc client")
+	return c.dialAggregatorRpcClient()
+}
+
+// Expected to be called with initialized client.
+func (c *AggregatorRpcClient) tryResendFromDeque() error {
+	c.messageDequeMutex.Lock()
+	defer c.messageDequeMutex.Unlock()
+
+	if len(c.messageDeque) != 0 {
+		c.logger.Info("Resending messages from queue")
+	}
+
+	for len(c.messageDeque) != 0 {
+		message := c.messageDeque[0]
+
+		// Assumes client exists
+		var err error
+		var reply bool
+
+		switch message.MessageType {
+		case CheckpointType:
+			signedCheckpointTaskResponse := message.Message.(*coretypes.SignedCheckpointTaskResponse)
+			// TODO(edwin): handle error
+			err = c.rpcClient.Call("Aggregator.ProcessSignedCheckpointTaskResponse", signedCheckpointTaskResponse, &reply)
+
+			//c.rpcClient.Call("Aggregator.ProcessSignedCheckpointTaskResponse", signedCheckpointTaskResponse, &reply)
+
+		case StateRootType:
+			signedStateRootUpdateMessage := message.Message.(*coretypes.SignedStateRootUpdateMessage)
+			err = c.rpcClient.Call("Aggregator.ProcessSignedStateRootUpdateMessage", signedStateRootUpdateMessage, &reply)
+
+		case OperatorSetUpdateType:
+			signedOperatorSetUpdateMessage := message.Message.(*coretypes.SignedOperatorSetUpdateMessage)
+			err = c.rpcClient.Call("Aggregator.ProcessSignedOperatorSetUpdateMessage", signedOperatorSetUpdateMessage, &reply)
+
+		default:
+			panic("unreachable")
+		}
+
+		if err != nil {
+			c.logger.Error("Couldn't resend message", "err", err)
+			return err
+		}
+
+		c.messageDeque = c.messageDeque[1:]
+	}
+
+	return nil
+}
+
 func (c *AggregatorRpcClient) SendSignedCheckpointTaskResponseToAggregator(signedCheckpointTaskResponse *coretypes.SignedCheckpointTaskResponse) {
 	c.logger.Info("Sending signed task response header to aggregator", "signedCheckpointTaskResponse", fmt.Sprintf("%#v", signedCheckpointTaskResponse))
 
-	c.sendRequest(func() error {
-		var reply bool
+	appendProtected := func() {
+		c.messageDequeMutex.Lock()
+		c.messageDeque = append(c.messageDeque, RpcMessageType{
+			MessageType: CheckpointType,
+			Message:     signedCheckpointTaskResponse,
+		})
+		c.messageDequeMutex.Unlock()
+	}
 
-		err := c.rpcClient.Call("Aggregator.ProcessSignedCheckpointTaskResponse", signedCheckpointTaskResponse, &reply)
-		if err != nil {
-			c.logger.Info("Received error from aggregator", "err", err)
-		} else {
-			c.logger.Info("Signed task response header accepted by aggregator.", "reply", reply)
-			c.metrics.IncNumTasksAcceptedByAggregator()
-		}
+	err := c.InitializeClientIfNotExist()
+	if err != nil {
+		appendProtected()
+		return
+	}
 
-		return err
-	}, 5, 2*time.Second)
+	err = c.tryResendFromDeque()
+	if err != nil {
+		appendProtected()
+		return
+	}
+
+	var reply bool
+	err = c.rpcClient.Call("Aggregator.ProcessSignedCheckpointTaskResponse", signedCheckpointTaskResponse, &reply)
+	if err != nil {
+		c.logger.Info("Received error from aggregator", "err", err)
+
+		// TODO(edwin): filter which errors to append
+		return
+		appendProtected()
+		return
+	}
+
+	c.logger.Info("Signed task response header accepted by aggregator.", "reply", reply)
+	c.metrics.IncNumMessagesAcceptedByAggregator()
 }
 
 func (c *AggregatorRpcClient) SendSignedStateRootUpdateToAggregator(signedStateRootUpdateMessage *coretypes.SignedStateRootUpdateMessage) {
 	c.logger.Info("Sending signed state root update message to aggregator", "signedStateRootUpdateMessage", fmt.Sprintf("%#v", signedStateRootUpdateMessage))
 
-	c.sendRequest(func() error {
-		var reply bool
+	appendProtected := func() {
+		c.messageDequeMutex.Lock()
+		c.messageDeque = append(c.messageDeque, RpcMessageType{
+			MessageType: StateRootType,
+			Message:     signedStateRootUpdateMessage,
+		})
+		c.messageDequeMutex.Unlock()
+	}
 
-		err := c.rpcClient.Call("Aggregator.ProcessSignedStateRootUpdateMessage", signedStateRootUpdateMessage, &reply)
-		if err != nil {
-			c.logger.Info("Received error from aggregator", "err", err)
-		} else {
-			c.logger.Info("Signed state root update message accepted by aggregator.", "reply", reply)
-			c.metrics.IncNumMessagesAcceptedByAggregator()
-		}
+	err := c.InitializeClientIfNotExist()
+	if err != nil {
+		appendProtected()
+		return
+	}
 
-		return err
-	}, 5, 2*time.Second)
+	err = c.tryResendFromDeque()
+	if err != nil {
+		appendProtected()
+		return
+	}
+
+	var reply bool
+	err = c.rpcClient.Call("Aggregator.ProcessSignedStateRootUpdateMessage", signedStateRootUpdateMessage, &reply)
+	if err != nil {
+		c.logger.Info("Received error from aggregator", "err", err)
+
+		appendProtected()
+		return
+	}
+
+	c.logger.Info("Signed state root update message accepted by aggregator.", "reply", reply)
+	c.metrics.IncNumMessagesAcceptedByAggregator()
 }
 
 func (c *AggregatorRpcClient) SendSignedOperatorSetUpdateToAggregator(signedOperatorSetUpdateMessage *coretypes.SignedOperatorSetUpdateMessage) {
 	c.logger.Info("Sending operator set update message to aggregator", "signedOperatorSetUpdateMessage", fmt.Sprintf("%#v", signedOperatorSetUpdateMessage))
 
-	c.sendRequest(func() error {
-		var reply bool
+	appendProtected := func() {
+		c.messageDequeMutex.Lock()
+		c.messageDeque = append(c.messageDeque, RpcMessageType{
+			MessageType: OperatorSetUpdateType,
+			Message:     signedOperatorSetUpdateMessage,
+		})
+		c.messageDequeMutex.Unlock()
+	}
 
-		err := c.rpcClient.Call("Aggregator.ProcessSignedOperatorSetUpdateMessage", signedOperatorSetUpdateMessage, &reply)
-		if err != nil {
-			c.logger.Info("Received error from aggregator", "err", err)
-		} else {
-			c.logger.Info("Signed operator set update message accepted by aggregator.", "reply", reply)
-			c.metrics.IncNumMessagesAcceptedByAggregator()
-		}
+	err := c.InitializeClientIfNotExist()
+	if err != nil {
+		appendProtected()
+		return
+	}
 
-		return err
-	}, 5, 2*time.Second)
+	err = c.tryResendFromDeque()
+	if err != nil {
+		appendProtected()
+		return
+	}
+
+	var reply bool
+	err = c.rpcClient.Call("Aggregator.ProcessSignedOperatorSetUpdateMessage", signedOperatorSetUpdateMessage, &reply)
+	if err != nil {
+		c.logger.Info("Received error from aggregator", "err", err)
+
+		appendProtected()
+		return
+	}
+
+	c.logger.Info("Signed operator set update message accepted by aggregator.", "reply", reply)
+	c.metrics.IncNumMessagesAcceptedByAggregator()
 }
+
+// Init if not initialized

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -75,12 +74,12 @@ func TestIntegration(t *testing.T) {
 		t.Fatalf("Task response hash is empty")
 	}
 
-	stateRootHeight, err := setup.rollupAnvils[1].getCurrentBlockHeight()
+	stateRootHeight, err := setup.rollupAnvils[1].HttpClient.BlockNumber(ctx)
 	if err != nil {
 		t.Fatalf("Cannot get current block height: %s", err.Error())
 	}
 
-	stateRootUpdate, err := getStateRootUpdateAggregation(setup.aggregatorRestUrl, uint32(setup.rollupAnvils[0].ChainID.Uint64()), stateRootHeight.Uint64()-1)
+	stateRootUpdate, err := getStateRootUpdateAggregation(setup.aggregatorRestUrl, uint32(setup.rollupAnvils[0].ChainID.Uint64()), stateRootHeight-1)
 	if err != nil {
 		t.Fatalf("Cannot get state root update: %s", err.Error())
 	}
@@ -115,12 +114,12 @@ func TestIntegration(t *testing.T) {
 		t.Fatalf("Wrong operator set update count")
 	}
 
-	stateRootHeight, err = setup.rollupAnvils[1].getCurrentBlockHeight()
+	stateRootHeight, err = setup.rollupAnvils[1].HttpClient.BlockNumber(ctx)
 	if err != nil {
 		t.Fatalf("Cannot get current block height: %s", err.Error())
 	}
 
-	stateRootUpdate, err = getStateRootUpdateAggregation(setup.aggregatorRestUrl, uint32(setup.rollupAnvils[0].ChainID.Uint64()), stateRootHeight.Uint64()-1)
+	stateRootUpdate, err = getStateRootUpdateAggregation(setup.aggregatorRestUrl, uint32(setup.rollupAnvils[0].ChainID.Uint64()), stateRootHeight-1)
 	if err != nil {
 		t.Fatalf("Cannot get state root update: %s", err.Error())
 	}
@@ -864,12 +863,4 @@ func (ai *AnvilInstance) setBalance(address common.Address, balance *big.Int) er
 
 func (ai *AnvilInstance) mine(blockCount, timestampInterval *big.Int) error {
 	return ai.WsClient.Client.Client().Call(nil, "anvil_mine", "0x"+blockCount.Text(16), "0x"+timestampInterval.Text(16))
-}
-
-func (ai *AnvilInstance) getCurrentBlockHeight() (*big.Int, error) {
-	var result hexutil.Big
-	if err := ai.WsClient.Client.Client().Call(&result, "eth_blockNumber"); err != nil {
-		return nil, err
-	}
-	return (*big.Int)(&result), nil
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -147,6 +147,7 @@ func TestIntegration(t *testing.T) {
 	}
 	assert.Equal(t, expectedUpdatedOperators, operatorSetUpdate.Message.Operators)
 
+	t.Log("Done")
 	<-ctx.Done()
 }
 
@@ -606,6 +607,8 @@ func startRollupIndexing(t *testing.T, ctx context.Context, rollupAnvils []*Anvi
 		go func() {
 			for {
 				select {
+				case <-ctx.Done():
+					return
 				case err := <-sub.Err():
 					t.Errorf("Error on rollup block subscription: %s", err.Error())
 					return
@@ -637,8 +640,6 @@ func startRollupIndexing(t *testing.T, ctx context.Context, rollupAnvils []*Anvi
 					}
 
 					submitBlock(t, ctx, getDaContractAccountId(anvil), block, indexerUrl)
-				case <-ctx.Done():
-					return
 				}
 			}
 		}()


### PR DESCRIPTION
Issues:
1. Prior messages that failed to be resend were dropped, hence never got to aggregator.
2. Port 5000 is occupied on Mac by Airplay

Introduced:
Rpc client now has a queue of unsent messages

1. All messages that failed to be send make it into queue.
2. On every new send we try to resend existing messages
3. The messages that failed to be send are remained in the queue
4. Try to send current message. In case failed see 1.

There's also a timer that occasionally triggers resend