### PR TITLE
Sort operators by pubkey hash

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -264,20 +264,13 @@ func (agg *Aggregator) sendAggregatedResponseToContract(blsAggServiceResp blsagg
 	taskResponse := agg.taskResponses[blsAggServiceResp.TaskIndex][blsAggServiceResp.TaskResponseDigest]
 	agg.taskResponsesLock.RUnlock()
 
-	aggregation := messages.MessageBlsAggregation{
-		EthBlockNumber:               uint64(task.TaskCreatedBlock),
-		MessageDigest:                blsAggServiceResp.TaskResponseDigest,
-		NonSignersPubkeysG1:          blsAggServiceResp.NonSignersPubkeysG1,
-		QuorumApksG1:                 blsAggServiceResp.QuorumApksG1,
-		SignersApkG2:                 blsAggServiceResp.SignersApkG2,
-		SignersAggSigG1:              blsAggServiceResp.SignersAggSigG1,
-		NonSignerQuorumBitmapIndices: blsAggServiceResp.NonSignerQuorumBitmapIndices,
-		QuorumApkIndices:             blsAggServiceResp.QuorumApkIndices,
-		TotalStakeIndices:            blsAggServiceResp.TotalStakeIndices,
-		NonSignerStakeIndices:        blsAggServiceResp.NonSignerStakeIndices,
+	aggregation, err := messages.NewMessageBlsAggregationFromServiceResponse(uint64(task.TaskCreatedBlock), blsAggServiceResp)
+	if err != nil {
+		agg.logger.Error("Aggregator failed to format aggregation", "err", err)
+		return
 	}
 
-	_, err := agg.avsWriter.SendAggregatedResponse(context.Background(), task, taskResponse, aggregation)
+	_, err = agg.avsWriter.SendAggregatedResponse(context.Background(), task, taskResponse, aggregation)
 	if err != nil {
 		agg.logger.Error("Aggregator failed to respond to task", "err", err)
 	}

--- a/core/types/messages/aggregation.go
+++ b/core/types/messages/aggregation.go
@@ -1,7 +1,11 @@
 package messages
 
 import (
+	"bytes"
+	"sort"
+
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	blsagg "github.com/Layr-Labs/eigensdk-go/services/bls_aggregation"
 
 	registryrollup "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLRegistryRollup"
 	taskmanager "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLTaskManager"
@@ -20,6 +24,49 @@ type MessageBlsAggregation struct {
 	QuorumApkIndices             []uint32
 	TotalStakeIndices            []uint32
 	NonSignerStakeIndices        [][]uint32
+}
+
+func NewMessageBlsAggregationFromServiceResponse(ethBlockNumber uint64, resp blsagg.BlsAggregationServiceResponse) (MessageBlsAggregation, error) {
+	nonSignersPubkeyHashes := make([][32]byte, 0, len(resp.NonSignersPubkeysG1))
+	for _, pubkey := range resp.NonSignersPubkeysG1 {
+		hash, err := core.HashBNG1Point(core.ConvertToBN254G1Point(pubkey))
+		if err != nil {
+			return MessageBlsAggregation{}, err
+		}
+
+		nonSignersPubkeyHashes = append(nonSignersPubkeyHashes, hash)
+	}
+
+	nonSignersPubkeys := append([]*bls.G1Point{}, resp.NonSignersPubkeysG1...)
+	nonSignerQuorumBitmapIndices := append([]uint32{}, resp.NonSignerQuorumBitmapIndices...)
+
+	nonSignerStakeIndices := make([][]uint32, 0, len(resp.NonSignerStakeIndices))
+	for _, nonSignerStakeIndex := range resp.NonSignerStakeIndices {
+		nonSignerStakeIndices = append(nonSignerStakeIndices, append([]uint32{}, nonSignerStakeIndex...))
+	}
+
+	sortByPubkeyHash := func(arr any) {
+		sort.Slice(arr, func(i, j int) bool {
+			return bytes.Compare(nonSignersPubkeyHashes[i][:], nonSignersPubkeyHashes[j][:]) == -1
+		})
+	}
+
+	sortByPubkeyHash(nonSignersPubkeys)
+	sortByPubkeyHash(nonSignerStakeIndices)
+	sortByPubkeyHash(nonSignerQuorumBitmapIndices)
+
+	return MessageBlsAggregation{
+		EthBlockNumber:               uint64(ethBlockNumber),
+		MessageDigest:                resp.TaskResponseDigest,
+		NonSignersPubkeysG1:          nonSignersPubkeys,
+		QuorumApksG1:                 resp.QuorumApksG1,
+		SignersApkG2:                 resp.SignersApkG2,
+		SignersAggSigG1:              resp.SignersAggSigG1,
+		NonSignerQuorumBitmapIndices: nonSignerQuorumBitmapIndices,
+		QuorumApkIndices:             resp.QuorumApkIndices,
+		TotalStakeIndices:            resp.TotalStakeIndices,
+		NonSignerStakeIndices:        nonSignerStakeIndices,
+	}, nil
 }
 
 func (msg MessageBlsAggregation) ExtractBindingMainnet() taskmanager.IBLSSignatureCheckerNonSignerStakesAndSignature {

--- a/core/utils.go
+++ b/core/utils.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"golang.org/x/crypto/sha3"
 
 	taskmanager "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLTaskManager"
@@ -37,4 +38,23 @@ func ConvertToBN254G2Point(input *bls.G2Point) taskmanager.BN254G2Point {
 		Y: [2]*big.Int{input.Y.A1.BigInt(big.NewInt(0)), input.Y.A0.BigInt(big.NewInt(0))},
 	}
 	return output
+}
+
+func HashBNG1Point(input taskmanager.BN254G1Point) ([32]byte, error) {
+	typ, err := abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "X", Type: "uint256"},
+		{Name: "Y", Type: "uint256"},
+	})
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	arguments := abi.Arguments{{Type: typ}}
+
+	bytes, err := arguments.Pack(input)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	return Keccak256(bytes)
 }


### PR DESCRIPTION
We were not previously sorting operators, which may have lead to issues (1) if there were non-signers, in terms of general aggregations, and (2) on operator set updates consensus.