### PR TITLE
Improve AVS registering flow

### DIFF
--- a/operator/operator.go
+++ b/operator/operator.go
@@ -467,11 +467,18 @@ func (o *Operator) registerOperatorOnStartup(
 	}
 	o.logger.Infof("Deposited %s into strategy %s", amount, mockTokenStrategyAddr)
 
-	err = o.avsManager.RegisterOperatorWithAvs(o.ethClient, operatorEcdsaPrivateKey, o.blsKeypair)
+	isOperatorRegistered, err := o.avsManager.avsReader.IsOperatorRegistered(&bind.CallOpts{}, o.operatorAddr)
 	if err != nil {
-		o.logger.Fatal("Error registering operator with avs", "err", err)
+		o.logger.Fatal("Error checking if operator is registered", "err", err)
 	}
-	o.logger.Infof("Registered operator with avs")
+
+	if !isOperatorRegistered {
+		err = o.avsManager.RegisterOperatorWithAvs(o.ethClient, operatorEcdsaPrivateKey, o.blsKeypair)
+		if err != nil {
+			o.logger.Fatal("Error registering operator with avs", "err", err)
+		}
+		o.logger.Infof("Registered operator with avs")
+	}
 }
 
 func (o *Operator) BlsPubkeyG1() *bls.G1Point {

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -480,6 +480,8 @@ func (o *Operator) registerOperatorOnStartup(
 			o.logger.Fatal("Error registering operator with avs", "err", err)
 		}
 		o.logger.Infof("Registered operator with avs")
+	} else {
+		o.logger.Infof("Operator already registered with avs")
 	}
 }
 

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -459,13 +459,15 @@ func (o *Operator) registerOperatorOnStartup(
 		o.logger.Infof("Registered operator with eigenlayer")
 	}
 
-	// TODO(samlaf): shouldn't hardcode number here
-	amount := big.NewInt(1000)
-	err = o.DepositIntoStrategy(mockTokenStrategyAddr, amount)
-	if err != nil {
-		o.logger.Fatal("Error depositing into strategy", "err", err)
+	if mockTokenStrategyAddr.Cmp(common.Address{}) != 0 {
+		// TODO(samlaf): shouldn't hardcode number here
+		amount := big.NewInt(1000)
+		err = o.DepositIntoStrategy(mockTokenStrategyAddr, amount)
+		if err != nil {
+			o.logger.Fatal("Error depositing into strategy", "err", err)
+		}
+		o.logger.Infof("Deposited %s into strategy %s", amount, mockTokenStrategyAddr)
 	}
-	o.logger.Infof("Deposited %s into strategy %s", amount, mockTokenStrategyAddr)
 
 	isOperatorRegistered, err := o.avsManager.avsReader.IsOperatorRegistered(&bind.CallOpts{}, o.operatorAddr)
 	if err != nil {

--- a/setup/operator/config/operator.yaml
+++ b/setup/operator/config/operator.yaml
@@ -18,7 +18,7 @@ enable_metrics: true
 node_api_ip_port_address: near-sffl-operator0:9010
 enable_node_api: true
 
-register_operator_on_startup: false
+register_operator_on_startup: true
 token_strategy_addr: 0x0000000000000000000000000000000000000000
 
 near_da_indexer_rmq_ip_port_address: amqp://rmq:5672


### PR DESCRIPTION
Now an operator can simply leave `register_operator_on_startup` as `true` by default - if it's not registered yet, it'll be registered, otherwise the registration will be simply skipped. This makes it unnecessary to use the operator plugin CLI for registering.