### PR TITLE
Resend from queue on message send only if successful

### DIFF
--- a/operator/rpc_client.go
+++ b/operator/rpc_client.go
@@ -162,14 +162,14 @@ func (c *AggregatorRpcClient) sendOperatorMessage(sendCb func() error, message R
 		return
 	}
 
-	c.tryResendFromDeque()
-
 	c.logger.Info("Sending request to aggregator")
 	err = sendCb()
 	if err != nil {
 		appendProtected()
 		return
 	}
+
+	c.tryResendFromDeque()
 }
 
 func (c *AggregatorRpcClient) sendRequest(sendCb func() error) error {


### PR DESCRIPTION
It seems excessive to try resending messages on every send, before the actual message is sent. If we know the original message send did not work, it doesn't make sense to retry for the enqueued ones.