### PR TITLE
Start indexing from latest block synced

### DIFF
--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -23,7 +23,7 @@ fn run(home_dir: std::path::PathBuf, config: RunConfigArgs) -> Result<()> {
 
     let indexer_config = near_indexer::IndexerConfig {
         home_dir,
-        sync_mode: near_indexer::SyncModeEnum::FromInterruption,
+        sync_mode: near_indexer::SyncModeEnum::LatestSynced,
         await_for_node_synced: near_indexer::AwaitForNodeSyncedEnum::WaitForFullSync,
         validate_genesis: true,
     };


### PR DESCRIPTION
Indexing from interruption was basically making it so it indexes *everything* from the latest interruption, effectively making it so the indexer would be behind the block rate for quite some time before actually reaching the current block.
This would be interesting if we made use of this capability somehow, but considering timeouts from MQ and message aggregation, if the indexer is ever stopped, the operator would already be inactive enough for this to be a fault and timeouts would be easily reached (startup takes quite a while).
In the end, keeping it like that only makes it so the operator doesn't realize there's a submission for current messages and has older messages to sign that he's already inactive for, which is what was happening in the testing environment.