### PR TITLE
Increase block data buffer on notifier

### DIFF
--- a/operator/attestor/notifier.go
+++ b/operator/attestor/notifier.go
@@ -28,7 +28,7 @@ func (notifier *Notifier) Subscribe(rollupId uint32) (<-chan consumer.BlockData,
 		notifier.rollupIdsToSubscribers[rollupId] = list.New()
 	}
 
-	notifierC := make(chan consumer.BlockData, 10)
+	notifierC := make(chan consumer.BlockData, 100)
 	id := notifier.rollupIdsToSubscribers[rollupId].PushBack(notifierC)
 
 	return notifierC, id


### PR DESCRIPTION
We were basically reaching a 'deadlock'-like state because the queue was full and as such the MQ listener was not being able to listen anymore.