### PR TITLE
Add additional gas to RespondToCheckpointTask transaction

### DIFF
--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -112,11 +112,21 @@ func (w *AvsWriter) SendAggregatedResponse(
 		w.logger.Errorf("Error getting tx opts")
 		return nil, err
 	}
+
 	tx, err := w.AvsContractBindings.TaskManager.RespondToCheckpointTask(txOpts, task, taskResponse.ToBinding(), aggregation.ExtractBindingMainnet())
 	if err != nil {
 		w.logger.Error("Error submitting SubmitTaskResponse tx while calling respondToTask", "err", err)
 		return nil, err
 	}
+
+	txOpts.GasLimit = tx.Gas() * 15 / 10
+
+	tx, err = w.AvsContractBindings.TaskManager.RespondToCheckpointTask(txOpts, task, taskResponse.ToBinding(), aggregation.ExtractBindingMainnet())
+	if err != nil {
+		w.logger.Error("Error submitting SubmitTaskResponse tx while calling respondToTask", "err", err)
+		return nil, err
+	}
+
 	receipt, err := w.TxMgr.Send(ctx, tx)
 	if err != nil {
 		w.logger.Errorf("Error submitting CreateCheckpointTask tx")


### PR DESCRIPTION
Currently, specifically the RespondToCheckpointTask submissions are reverting because of OOG. This is curious because it's the only transaction in which it happens, but it's the case. Still, for basically any call it seems like `go-ethereum` doesn't add a considerable amount of extra gas to avoid issues, most transactions are really really close. For calls that are afected by the state somehow, it would be good to follow a similar approach. Double-checked replaying it through a fork and it works with a tiny bit more gas.