### PR TITLE
Increase relayer intervals

### DIFF
--- a/operator/attestor/notifier.go
+++ b/operator/attestor/notifier.go
@@ -28,7 +28,7 @@ func (notifier *Notifier) Subscribe(rollupId uint32) (<-chan consumer.BlockData,
 		notifier.rollupIdsToSubscribers[rollupId] = list.New()
 	}
 
-	notifierC := make(chan consumer.BlockData, 100)
+	notifierC := make(chan consumer.BlockData, 150)
 	id := notifier.rollupIdsToSubscribers[rollupId].PushBack(notifierC)
 
 	return notifierC, id

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -17,8 +17,8 @@ import (
 
 const (
 	NAMESPACE_ID               = 1
-	SUBMIT_BLOCK_INTERVAL      = 1500 * time.Millisecond
-	SUBMIT_BLOCK_RETRY_TIMEOUT = 1 * time.Second
+	SUBMIT_BLOCK_INTERVAL      = 2500 * time.Millisecond
+	SUBMIT_BLOCK_RETRY_TIMEOUT = 2 * time.Second
 	SUBMIT_BLOCK_RETRIES       = 3
 )
 


### PR DESCRIPTION
We're probably overestimating NEAR's throughput here. Even with these changes, transactions are still expiring (after 3 retries) frequently. Still going to try increasing the usual interval a bit more and also retries to check this out, as it's unclear whether this is affected by our transaction rate or not. Maybe we need to push this through another RPC besides the default one?

Even on a retry it's still nowhere near 100, but I also increased notifier's channel queue size for some additional safety - we can probably increase it quite a bit more still.