### PR TITLE
Add logrotate to setup docker composes

### DIFF
--- a/setup/aggregator/docker-compose.yml
+++ b/setup/aggregator/docker-compose.yml
@@ -19,6 +19,12 @@ services:
       - "4001:4001"
       - "4002:4002"
       - "9091:9091"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1g"
+        max-file: "50"
+        compress: "true"
 
   grafana:
     image: grafana/grafana:9.4.1

--- a/setup/operator/docker-compose.yml
+++ b/setup/operator/docker-compose.yml
@@ -45,6 +45,12 @@ services:
     restart: unless-stopped
     networks:
       - near-sffl
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1g"
+        max-file: "10"
+        compress: "true"
 
   operator:
     profiles: [operator]
@@ -67,6 +73,12 @@ services:
     restart: unless-stopped
     networks:
       - near-sffl
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1g"
+        max-file: "50"
+        compress: "true"
 
   operator-health:
     profiles: [operator]

--- a/setup/relayer/docker-compose.yml
+++ b/setup/relayer/docker-compose.yml
@@ -16,6 +16,12 @@ services:
       - --network
       - ${NEAR_RPC_URL}
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1g"
+        max-file: "20"
+        compress: "true"
 
   relayer_11155420:
     image: ghcr.io/nethermindeth/near-sffl/relayer:${SFFL_RELEASE}
@@ -32,3 +38,9 @@ services:
       - --network
       - ${NEAR_RPC_URL}
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1g"
+        max-file: "20"
+        compress: "true"


### PR DESCRIPTION
Just adds logrotate to the main containers. These are pretty big limits, but we are logging a lot (and it's good we do it - though I think I can remove some of the mq logs on operator, it's a bit much), but this will make sure it will not blow up anyone's storage.