### PR TITLE
Only respond to task in the next block

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -331,6 +331,17 @@ func (agg *Aggregator) sendAggregatedResponseToContract(blsAggServiceResp blsagg
 		return
 	}
 
+	currentBlock, err := agg.client.BlockNumber(context.Background())
+	if err != nil {
+		agg.logger.Errorf("Error getting current block number", "err", err)
+		return
+	}
+
+	if uint64(task.TaskCreatedBlock) == currentBlock {
+		agg.logger.Info("Waiting roughly a block before sending aggregated response...")
+		time.Sleep(20 * time.Second)
+	}
+
 	_, err = agg.avsWriter.SendAggregatedResponse(context.Background(), task, taskResponse, aggregation)
 	if err != nil {
 		agg.logger.Error("Aggregator failed to respond to task", "err", err)

--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -2,6 +2,7 @@ package chainio
 
 import (
 	"context"
+	"time"
 
 	"github.com/NethermindEth/near-sffl/core/config"
 	"github.com/NethermindEth/near-sffl/core/types/messages"
@@ -107,6 +108,18 @@ func (w *AvsWriter) SendAggregatedResponse(
 	taskResponse messages.CheckpointTaskResponse,
 	aggregation messages.MessageBlsAggregation,
 ) (*types.Receipt, error) {
+	// Wait a block if the task TaskCreatedBlock is the same as the current block
+	currentBlock, err := w.client.BlockNumber(ctx)
+	if err != nil {
+		w.logger.Errorf("Error getting current block number")
+		return nil, err
+	}
+
+	if uint64(task.TaskCreatedBlock) == currentBlock {
+		w.logger.Info("Waiting roughly a block before sending aggregated response...")
+		time.Sleep(20 * time.Second)
+	}
+
 	txOpts, err := w.TxMgr.GetNoSendTxOpts()
 	if err != nil {
 		w.logger.Errorf("Error getting tx opts")

--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -66,15 +66,16 @@ func BuildAvsWriter(txMgr txmgr.TxManager, registryCoordinatorAddr, operatorStat
 	if err != nil {
 		return nil, err
 	}
-	return NewAvsWriter(avsRegistryWriter, avsServiceBindings, logger, txMgr), nil
+	return NewAvsWriter(avsRegistryWriter, avsServiceBindings, ethHttpClient, logger, txMgr), nil
 }
 
-func NewAvsWriter(avsRegistryWriter avsregistry.AvsRegistryWriter, avsServiceBindings *AvsManagersBindings, logger logging.Logger, txMgr txmgr.TxManager) *AvsWriter {
+func NewAvsWriter(avsRegistryWriter avsregistry.AvsRegistryWriter, avsServiceBindings *AvsManagersBindings, client eth.Client, logger logging.Logger, txMgr txmgr.TxManager) *AvsWriter {
 	return &AvsWriter{
 		AvsRegistryWriter:   avsRegistryWriter,
 		AvsContractBindings: avsServiceBindings,
-		logger:              logger,
 		TxMgr:               txMgr,
+		client:              client,
+		logger:              logger,
 	}
 }
 

--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -2,7 +2,6 @@ package chainio
 
 import (
 	"context"
-	"time"
 
 	"github.com/NethermindEth/near-sffl/core/config"
 	"github.com/NethermindEth/near-sffl/core/types/messages"
@@ -109,18 +108,6 @@ func (w *AvsWriter) SendAggregatedResponse(
 	taskResponse messages.CheckpointTaskResponse,
 	aggregation messages.MessageBlsAggregation,
 ) (*types.Receipt, error) {
-	// Wait a block if the task TaskCreatedBlock is the same as the current block
-	currentBlock, err := w.client.BlockNumber(ctx)
-	if err != nil {
-		w.logger.Errorf("Error getting current block number")
-		return nil, err
-	}
-
-	if uint64(task.TaskCreatedBlock) == currentBlock {
-		w.logger.Info("Waiting roughly a block before sending aggregated response...")
-		time.Sleep(20 * time.Second)
-	}
-
 	txOpts, err := w.TxMgr.GetNoSendTxOpts()
 	if err != nil {
 		w.logger.Errorf("Error getting tx opts")

--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -46,7 +46,6 @@ type AvsWriter struct {
 	AvsContractBindings *AvsManagersBindings
 	logger              logging.Logger
 	TxMgr               txmgr.TxManager
-	client              eth.Client
 }
 
 var _ AvsWriterer = (*AvsWriter)(nil)
@@ -73,7 +72,6 @@ func NewAvsWriter(avsRegistryWriter avsregistry.AvsRegistryWriter, avsServiceBin
 		AvsRegistryWriter:   avsRegistryWriter,
 		AvsContractBindings: avsServiceBindings,
 		TxMgr:               txMgr,
-		client:              client,
 		logger:              logger,
 	}
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -60,7 +60,7 @@ func TestIntegration(t *testing.T) {
 		setup.cleanup()
 	})
 
-	time.Sleep(30 * time.Second)
+	time.Sleep(55 * time.Second)
 
 	taskHash, err := setup.avsReader.AvsServiceBindings.TaskManager.AllCheckpointTaskHashes(&bind.CallOpts{}, 0)
 	if err != nil {


### PR DESCRIPTION
Because of how the EL BLS aggregation contracts work, you can't respond to a task in the same block it was created.