### PR TITLE
Check registry coordinator addresses match on operator startup

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -72,6 +72,7 @@ const (
 // Upon sending a task onchain (or receiving a CheckpointTaskCreated Event if the tasks were sent by an external task generator), the aggregator can get the list of all operators opted into each quorum at that
 // block number by calling the getOperatorState() function of the BLSOperatorStateRetriever.sol contract.
 type Aggregator struct {
+	config               *config.Config
 	logger               logging.Logger
 	serverIpPortAddr     string
 	restServerIpPortAddr string
@@ -203,6 +204,7 @@ func NewAggregator(ctx context.Context, config *config.Config, logger logging.Lo
 	operatorSetUpdateBlsAggregationService := NewMessageBlsAggregatorService(avsRegistryService, clients.EthHttpClient, logger)
 
 	agg := &Aggregator{
+		config:                                 config,
 		logger:                                 logger,
 		serverIpPortAddr:                       config.AggregatorServerIpPortAddr,
 		restServerIpPortAddr:                   config.AggregatorRestServerIpPortAddr,

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -146,3 +146,8 @@ func (agg *Aggregator) GetAggregatedCheckpointMessages(args *GetAggregatedCheckp
 
 	return nil
 }
+
+func (agg *Aggregator) GetRegistryCoordinatorAddress(reply *string) error {
+	*reply = agg.config.SFFLRegistryCoordinatorAddr.String()
+	return nil
+}

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -147,7 +147,7 @@ func (agg *Aggregator) GetAggregatedCheckpointMessages(args *GetAggregatedCheckp
 	return nil
 }
 
-func (agg *Aggregator) GetRegistryCoordinatorAddress(reply *string) error {
+func (agg *Aggregator) GetRegistryCoordinatorAddress(_ *struct{}, reply *string) error {
 	*reply = agg.config.SFFLRegistryCoordinatorAddr.String()
 	return nil
 }

--- a/operator/mocks/rpc_client.go
+++ b/operator/mocks/rpc_client.go
@@ -68,6 +68,21 @@ func (mr *MockAggregatorRpcClienterMockRecorder) GetAggregatedCheckpointMessages
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAggregatedCheckpointMessages", reflect.TypeOf((*MockAggregatorRpcClienter)(nil).GetAggregatedCheckpointMessages), arg0, arg1)
 }
 
+// GetRegistryCoordinatorAddress mocks base method.
+func (m *MockAggregatorRpcClienter) GetRegistryCoordinatorAddress() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegistryCoordinatorAddress")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegistryCoordinatorAddress indicates an expected call of GetRegistryCoordinatorAddress.
+func (mr *MockAggregatorRpcClienterMockRecorder) GetRegistryCoordinatorAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistryCoordinatorAddress", reflect.TypeOf((*MockAggregatorRpcClienter)(nil).GetRegistryCoordinatorAddress))
+}
+
 // SendSignedCheckpointTaskResponseToAggregator mocks base method.
 func (m *MockAggregatorRpcClienter) SendSignedCheckpointTaskResponseToAggregator(arg0 *messages.SignedCheckpointTaskResponse) {
 	m.ctrl.T.Helper()

--- a/operator/mocks/rpc_client.go
+++ b/operator/mocks/rpc_client.go
@@ -68,21 +68,6 @@ func (mr *MockAggregatorRpcClienterMockRecorder) GetAggregatedCheckpointMessages
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAggregatedCheckpointMessages", reflect.TypeOf((*MockAggregatorRpcClienter)(nil).GetAggregatedCheckpointMessages), arg0, arg1)
 }
 
-// GetRegistryCoordinatorAddress mocks base method.
-func (m *MockAggregatorRpcClienter) GetRegistryCoordinatorAddress() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegistryCoordinatorAddress")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRegistryCoordinatorAddress indicates an expected call of GetRegistryCoordinatorAddress.
-func (mr *MockAggregatorRpcClienterMockRecorder) GetRegistryCoordinatorAddress() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistryCoordinatorAddress", reflect.TypeOf((*MockAggregatorRpcClienter)(nil).GetRegistryCoordinatorAddress))
-}
-
 // SendSignedCheckpointTaskResponseToAggregator mocks base method.
 func (m *MockAggregatorRpcClienter) SendSignedCheckpointTaskResponseToAggregator(arg0 *messages.SignedCheckpointTaskResponse) {
 	m.ctrl.T.Helper()

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -61,7 +60,7 @@ type Operator struct {
 	// rpc client to send signed task responses to aggregator
 	aggregatorRpcClient AggregatorRpcClienter
 	// needed when opting in to avs (allow this service manager contract to slash operator)
-	sfflServiceManagerAddr common.Address
+	registryCoordinatorAddr common.Address
 	// NEAR DA indexer consumer
 	attestor attestor.Attestorer
 	// Avs Manager
@@ -168,7 +167,8 @@ func NewOperatorFromConfig(c optypes.NodeConfig) (*Operator, error) {
 	// Use eigen registry
 	reg = sdkClients.PrometheusRegistry
 
-	aggregatorRpcClient, err := NewAggregatorRpcClient(c.AggregatorServerIpPortAddress, logger)
+	registryCoordinatorAddress := common.HexToAddress(c.AVSRegistryCoordinatorAddress)
+	aggregatorRpcClient, err := NewAggregatorRpcClient(c.AggregatorServerIpPortAddress, registryCoordinatorAddress, logger)
 	if err != nil {
 		logger.Error("Cannot create AggregatorRpcClient. Is aggregator running?", "err", err)
 		return nil, err
@@ -204,18 +204,8 @@ func NewOperatorFromConfig(c optypes.NodeConfig) (*Operator, error) {
 		operatorAddr:               common.HexToAddress(c.OperatorAddress),
 		aggregatorServerIpPortAddr: c.AggregatorServerIpPortAddress,
 		aggregatorRpcClient:        aggregatorRpcClient,
-		sfflServiceManagerAddr:     common.HexToAddress(c.AVSRegistryCoordinatorAddress),
+		registryCoordinatorAddr:    registryCoordinatorAddress,
 		operatorId:                 eigentypes.OperatorIdFromPubkey(blsKeyPair.GetPubKeyG1()),
-	}
-
-	registryCoordinatorAddress, err := operator.aggregatorRpcClient.GetRegistryCoordinatorAddress()
-	if err != nil {
-		logger.Error("Failed to get registry coordinator address from aggregator", "err", err)
-		return nil, err
-	}
-	if registryCoordinatorAddress != common.HexToAddress(c.AVSRegistryCoordinatorAddress).String() {
-		logger.Error("Registry coordinator address from aggregator does not match the one in the config", "aggregator", registryCoordinatorAddress, "config", c.AVSRegistryCoordinatorAddress)
-		return nil, errors.New("registry coordinator address from aggregator does not match the one in the config")
 	}
 
 	if c.RegisterOperatorOnStartup {

--- a/operator/rpc_client.go
+++ b/operator/rpc_client.go
@@ -97,7 +97,7 @@ func (c *AggregatorRpcClient) dialAggregatorRpcClient() error {
 	}
 
 	var aggregatorRegistryCoordinatorAddress string
-	err = client.Call("Aggregator.GetRegistryCoordinatorAddress", nil, &aggregatorRegistryCoordinatorAddress)
+	err = client.Call("Aggregator.GetRegistryCoordinatorAddress", struct{}{}, &aggregatorRegistryCoordinatorAddress)
 	if err != nil {
 		c.logger.Info("Received error when getting registry coordinator address", "err", err)
 		return err

--- a/operator/rpc_client.go
+++ b/operator/rpc_client.go
@@ -103,7 +103,7 @@ func (c *AggregatorRpcClient) dialAggregatorRpcClient() error {
 	}
 
 	if common.HexToAddress(aggregatorRegistryCoordinatorAddress).Cmp(c.registryCoordinatorAddress) != 0 {
-		c.logger.Error("Registry coordinator address from aggregator does not match the one in the config", "aggregator", aggregatorRegistryCoordinatorAddress, "config", c.registryCoordinatorAddress.String())
+		c.logger.Fatal("Registry coordinator address from aggregator does not match the one in the config", "aggregator", aggregatorRegistryCoordinatorAddress, "config", c.registryCoordinatorAddress.String())
 		return errors.New("mismatching registry coordinator address from aggregator")
 	}
 

--- a/operator/rpc_client.go
+++ b/operator/rpc_client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/NethermindEth/near-sffl/core"
@@ -36,9 +37,10 @@ type unsentRpcMessage struct {
 }
 
 type AggregatorRpcClient struct {
-	rpcClientLock        sync.RWMutex
-	rpcClient            *rpc.Client
-	aggregatorIpPortAddr string
+	rpcClientLock              sync.RWMutex
+	rpcClient                  *rpc.Client
+	aggregatorIpPortAddr       string
+	registryCoordinatorAddress common.Address
 
 	unsentMessagesLock sync.Mutex
 	unsentMessages     []unsentRpcMessage
@@ -50,22 +52,18 @@ type AggregatorRpcClient struct {
 
 var _ core.Metricable = (*AggregatorRpcClient)(nil)
 
-func NewAggregatorRpcClient(aggregatorIpPortAddr string, logger logging.Logger) (*AggregatorRpcClient, error) {
+func NewAggregatorRpcClient(aggregatorIpPortAddr string, registryCoordinatorAddress common.Address, logger logging.Logger) (*AggregatorRpcClient, error) {
 	resendTicker := time.NewTicker(ResendInterval)
 
 	client := &AggregatorRpcClient{
 		// set to nil so that we can create an rpc client even if the aggregator is not running
-		rpcClient:            nil,
-		logger:               logger,
-		aggregatorIpPortAddr: aggregatorIpPortAddr,
-		unsentMessages:       make([]unsentRpcMessage, 0),
-		resendTicker:         resendTicker,
-		listener:             &SelectiveRpcClientListener{},
-	}
-
-	err := client.InitializeClientIfNotExist()
-	if err != nil {
-		return nil, err
+		rpcClient:                  nil,
+		logger:                     logger,
+		aggregatorIpPortAddr:       aggregatorIpPortAddr,
+		registryCoordinatorAddress: registryCoordinatorAddress,
+		unsentMessages:             make([]unsentRpcMessage, 0),
+		resendTicker:               resendTicker,
+		listener:                   &SelectiveRpcClientListener{},
 	}
 
 	go client.onTick()
@@ -96,6 +94,18 @@ func (c *AggregatorRpcClient) dialAggregatorRpcClient() error {
 	if err != nil {
 		c.logger.Error("Error dialing aggregator rpc client", "err", err)
 		return err
+	}
+
+	var aggregatorRegistryCoordinatorAddress string
+	err = client.Call("Aggregator.GetRegistryCoordinatorAddress", nil, &aggregatorRegistryCoordinatorAddress)
+	if err != nil {
+		c.logger.Info("Received error when getting registry coordinator address", "err", err)
+		return err
+	}
+
+	if common.HexToAddress(aggregatorRegistryCoordinatorAddress).Cmp(c.registryCoordinatorAddress) != 0 {
+		c.logger.Error("Registry coordinator address from aggregator does not match the one in the config", "aggregator", aggregatorRegistryCoordinatorAddress, "config", c.registryCoordinatorAddress.String())
+		return errors.New("mismatching registry coordinator address from aggregator")
 	}
 
 	c.rpcClient = client

--- a/operator/rpc_client.go
+++ b/operator/rpc_client.go
@@ -28,7 +28,6 @@ type AggregatorRpcClienter interface {
 	SendSignedStateRootUpdateToAggregator(signedStateRootUpdateMessage *messages.SignedStateRootUpdateMessage)
 	SendSignedOperatorSetUpdateToAggregator(signedOperatorSetUpdateMessage *messages.SignedOperatorSetUpdateMessage)
 	GetAggregatedCheckpointMessages(fromTimestamp, toTimestamp uint64) (*messages.CheckpointMessages, error)
-	GetRegistryCoordinatorAddress() (string, error)
 }
 
 type unsentRpcMessage struct {
@@ -371,23 +370,4 @@ func (c *AggregatorRpcClient) GetAggregatedCheckpointMessages(fromTimestamp, toT
 	}
 
 	return &checkpointMessages, nil
-}
-
-func (c *AggregatorRpcClient) GetRegistryCoordinatorAddress() (string, error) {
-	var reply string
-	err := c.sendRequest(func() error {
-		err := c.rpcClient.Call("Aggregator.GetRegistryCoordinatorAddress", nil, &reply)
-		if err != nil {
-			c.logger.Info("Received error from aggregator", "err", err)
-			return err
-		}
-
-		c.logger.Info("Checkpoint messages fetched from aggregator")
-		return nil
-	})
-	if err != nil {
-		return "", err
-	}
-
-	return reply, nil
 }


### PR DESCRIPTION
This introduces a check for the aggregator's `RegistryCoordinator` address in the operator as an additional layer to detect misconfigurations. If they don't match, it means the operator is misconfigured in either the contract address or the aggregator socket. Still not totally sure if this should be a `Fatal` or not.