### PR TITLE
Avoid re-initializing operator set

### DIFF
--- a/aggregator/rollup_broadcaster.go
+++ b/aggregator/rollup_broadcaster.go
@@ -128,6 +128,9 @@ func (b *RollupBroadcaster) initializeRollupOperatorSetsOnUpdate(ctx context.Con
 					}
 				}(writer)
 			}
+
+			operatorSetUpdateSub.Unsubscribe()
+			return
 		}
 	}
 }


### PR DESCRIPTION
This does not really have any impact as it doesn't actually re-initialize, since the simulated calls would revert anyway. 