### PR TITLE
Fix double decrement on SafeEthClient wg

### DIFF
--- a/core/safeclient/client.go
+++ b/core/safeclient/client.go
@@ -158,8 +158,6 @@ func (c *SafeEthClient) handleReinitEvent() {
 		return
 	}
 
-	defer c.wg.Done()
-
 	c.isReinitializing = true
 
 	c.wg.Add(1)


### PR DESCRIPTION
Just noticed something that passed us by during #154 - `handleReinitEvent` has a `defer c.wg.Done()` even though the wait group is not incremented when it's called. It was probably a byproduct of a refactor, as now it spawns it's own task. In this case, it makes sense to just remove it.