### PR TITLE
Fix likely deadlock issue in SafeClient

### DIFF
--- a/core/safeclient/client.go
+++ b/core/safeclient/client.go
@@ -505,19 +505,13 @@ func (c *SafeEthClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.H
 				}
 			case <-sub.Err():
 				c.logger.Info("Underlying subscription to new heads ended, resubscribing")
-				err := resub()
-				if err = c.handleClientError(err); err != nil {
-					c.logger.Error("Failed to resubscribe to new heads", "err", err)
-				}
+				c.triggerReinit()
 			case <-headerTicker.C:
 				c.logger.Info("Header ticker fired, ending subscription")
 				if receivedBlock {
 					receivedBlock = false
 				} else {
-					err := resub()
-					if err = c.handleClientError(err); err != nil {
-						c.logger.Error("Failed to resubscribe to new heads", "err", err)
-					}
+					c.triggerReinit()
 				}
 			case <-c.closeC:
 				c.logger.Info("Received close signal, ending new heads subscription")


### PR DESCRIPTION
From our testing data on operator state root messaging, it seems quite likely there's a deadlock happening in `SafeClient` for block submissions. Would be good to get an overall review on it. Trying to change some of the approaches that seem problematic while I get more info on it, at the moment:
* Centralized resubbing in reinits, so there's no way a resub can happen while it's reinitializing
* Made resubs not block the event listening from the subscription task

Good to highlight the rollup clients are only used for header subscriptions, so it's down to `SubscribeNewHead` specifically.