### PR TITLE
Add operator initialization metric to aggregator

### DIFF
--- a/aggregator/metrics.go
+++ b/aggregator/metrics.go
@@ -14,7 +14,7 @@ const (
 )
 
 type RpcEventListener interface {
-	IncOperatorReinitializations(operatorId [32]byte)
+	IncOperatorInitializations(operatorId [32]byte)
 	IncSignedCheckpointTaskResponse(operatorId [32]byte, errored, notFound bool)
 	IncSignedStateRootUpdateMessage(operatorId [32]byte, errored, hasNearDa bool)
 	IncSignedOperatorSetUpdateMessage(operatorId [32]byte, errored bool)
@@ -25,7 +25,7 @@ type RpcEventListener interface {
 }
 
 type SelectiveRpcListener struct {
-	IncOperatorReinitializationsCb           func(operatorId [32]byte)
+	IncOperatorInitializationsCb             func(operatorId [32]byte)
 	IncSignedCheckpointTaskResponseCb        func(operatorId [32]byte, errored, notFound bool)
 	IncSignedStateRootUpdateMessageCb        func(operatorId [32]byte, errored, hasNearDa bool)
 	IncSignedOperatorSetUpdateMessageCb      func(operatorId [32]byte, errored bool)
@@ -35,9 +35,9 @@ type SelectiveRpcListener struct {
 	ObserveLastMessageReceivedTimeCb         func(operatorId [32]byte, messageType string)
 }
 
-func (l *SelectiveRpcListener) IncOperatorReinitializations(operatorId [32]byte) {
-	if l.IncOperatorReinitializationsCb != nil {
-		l.IncOperatorReinitializationsCb(operatorId)
+func (l *SelectiveRpcListener) IncOperatorInitializations(operatorId [32]byte) {
+	if l.IncOperatorInitializationsCb != nil {
+		l.IncOperatorInitializationsCb(operatorId)
 	}
 }
 
@@ -269,16 +269,16 @@ func MakeRestServerMetrics(registry *prometheus.Registry) (RestEventListener, er
 }
 
 func MakeRpcServerMetrics(registry *prometheus.Registry) (RpcEventListener, error) {
-	operatorReinitializationsTotal := prometheus.NewCounterVec(
+	operatorInitializationsTotal := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: AggregatorNamespace,
-			Name:      "operator_reinitializations_total",
-			Help:      "Total number of operator reinitializations",
+			Name:      "operator_initializations_total",
+			Help:      "Total number of operator initializations",
 		},
 		[]string{"operator_id"},
 	)
-	if err := registry.Register(operatorReinitializationsTotal); err != nil {
-		return nil, fmt.Errorf("error registering operatorReinitializationsTotal counter: %w", err)
+	if err := registry.Register(operatorInitializationsTotal); err != nil {
+		return nil, fmt.Errorf("error registering operatorInitializationsTotal counter: %w", err)
 	}
 
 	signedCheckpointTaskResponsesTotal := prometheus.NewCounterVec(
@@ -330,8 +330,8 @@ func MakeRpcServerMetrics(registry *prometheus.Registry) (RpcEventListener, erro
 	}
 
 	return &SelectiveRpcListener{
-		IncOperatorReinitializationsCb: func(operatorId [32]byte) {
-			operatorReinitializationsTotal.WithLabelValues(fmt.Sprintf("%x", operatorId)).Inc()
+		IncOperatorInitializationsCb: func(operatorId [32]byte) {
+			operatorInitializationsTotal.WithLabelValues(fmt.Sprintf("%x", operatorId)).Inc()
 		},
 		IncSignedCheckpointTaskResponseCb: func(operatorId [32]byte, errored, expired bool) {
 			signedCheckpointTaskResponsesTotal.WithLabelValues(fmt.Sprintf("%x", operatorId), fmt.Sprintf("%t", errored), fmt.Sprintf("%t", expired)).Inc()

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -201,7 +201,7 @@ func (agg *Aggregator) GetRegistryCoordinatorAddress(_ *struct{}, reply *string)
 	return nil
 }
 
-func (agg *Aggregator) NotifyOperatorInitialization(operatorId [32]byte, reply *bool) error {
+func (agg *Aggregator) NotifyOperatorInitialization(operatorId eigentypes.OperatorId, reply *bool) error {
 	agg.rpcListener.IncOperatorInitializations(operatorId)
 	return nil
 }

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -200,3 +200,8 @@ func (agg *Aggregator) GetRegistryCoordinatorAddress(_ *struct{}, reply *string)
 	*reply = agg.config.SFFLRegistryCoordinatorAddr.String()
 	return nil
 }
+
+func (agg *Aggregator) NotifyOperatorReinitialization(operatorId [32]byte, reply *bool) error {
+	agg.rpcListener.IncOperatorReinitializations(operatorId)
+	return nil
+}

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -201,7 +201,7 @@ func (agg *Aggregator) GetRegistryCoordinatorAddress(_ *struct{}, reply *string)
 	return nil
 }
 
-func (agg *Aggregator) NotifyOperatorReinitialization(operatorId [32]byte, reply *bool) error {
-	agg.rpcListener.IncOperatorReinitializations(operatorId)
+func (agg *Aggregator) NotifyOperatorInitialization(operatorId [32]byte, reply *bool) error {
+	agg.rpcListener.IncOperatorInitializations(operatorId)
 	return nil
 }

--- a/grafana/provisioning/dashboards/AVSs/aggregator.json
+++ b/grafana/provisioning/dashboards/AVSs/aggregator.json
@@ -632,6 +632,98 @@
       "fieldConfig": {
         "defaults": {
           "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 18,
+        "x": 0,
+        "y": 13
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sffl_aggregator_operator_initializations_total{operator_id=\"$operatorId\"}",
+          "legendFormat": "Initializations",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Operator Initializations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
             "mode": "thresholds"
           },
           "mappings": [],
@@ -669,7 +761,7 @@
         "h": 10,
         "w": 9,
         "x": 0,
-        "y": 13
+        "y": 20
       },
       "id": 4,
       "options": {
@@ -771,7 +863,7 @@
         "h": 10,
         "w": 9,
         "x": 9,
-        "y": 13
+        "y": 20
       },
       "id": 16,
       "options": {
@@ -836,7 +928,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -874,6 +966,6 @@
   "timezone": "",
   "title": "Aggregator",
   "uid": "b3FGg5PIz",
-  "version": 8,
+  "version": 9,
   "weekStart": ""
 }

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -104,6 +104,8 @@ func NewOperatorFromConfig(c optypes.NodeConfig) (*Operator, error) {
 		return nil, err
 	}
 
+	operatorId := eigentypes.OperatorIdFromPubkey(blsKeyPair.GetPubKeyG1())
+
 	ecdsaKeyPassword, ok := os.LookupEnv("OPERATOR_ECDSA_KEY_PASSWORD")
 	if !ok {
 		logger.Warnf("OPERATOR_ECDSA_KEY_PASSWORD env var not set. using empty string")
@@ -170,7 +172,7 @@ func NewOperatorFromConfig(c optypes.NodeConfig) (*Operator, error) {
 	reg = sdkClients.PrometheusRegistry
 
 	registryCoordinatorAddress := common.HexToAddress(c.AVSRegistryCoordinatorAddress)
-	aggregatorRpcClient, err := NewAggregatorRpcClient(c.AggregatorServerIpPortAddress, registryCoordinatorAddress, logger)
+	aggregatorRpcClient, err := NewAggregatorRpcClient(c.AggregatorServerIpPortAddress, operatorId, registryCoordinatorAddress, logger)
 	if err != nil {
 		logger.Error("Cannot create AggregatorRpcClient. Is aggregator running?", "err", err)
 		return nil, err
@@ -207,7 +209,7 @@ func NewOperatorFromConfig(c optypes.NodeConfig) (*Operator, error) {
 		aggregatorServerIpPortAddr: c.AggregatorServerIpPortAddress,
 		aggregatorRpcClient:        aggregatorRpcClient,
 		registryCoordinatorAddr:    registryCoordinatorAddress,
-		operatorId:                 eigentypes.OperatorIdFromPubkey(blsKeyPair.GetPubKeyG1()),
+		operatorId:                 operatorId,
 		taskResponseWait:           time.Duration(c.TaskResponseWaitMs) * time.Millisecond,
 	}
 

--- a/operator/rpc_client.go
+++ b/operator/rpc_client.go
@@ -107,9 +107,10 @@ func (c *AggregatorRpcClient) dialAggregatorRpcClient() error {
 		c.logger.Info("Notifying aggregator of initialization")
 
 		var reply bool
-		err := c.rpcClient.Call("Aggregator.NotifyOperatorInitialization", struct{}{}, &reply)
+		err := client.Call("Aggregator.NotifyOperatorInitialization", struct{}{}, &reply)
 		if err != nil {
 			c.logger.Error("Error notifying aggregator of initialization", "err", err)
+			return err
 		}
 
 		c.notifiedInitialized = true


### PR DESCRIPTION
Adds a simple metric to track operator initializations in aggregator. The idea here is not that we strictly need to know that operator X has initialized, but at least have some kind of ping so we can detect crashes if they happen.