### PR TITLE
Standardize subscription error handling

### DIFF
--- a/aggregator/rollup_broadcaster.go
+++ b/aggregator/rollup_broadcaster.go
@@ -94,16 +94,10 @@ func (b *RollupBroadcaster) initializeRollupOperatorSetsOnUpdate(ctx context.Con
 		case <-ctx.Done():
 			return
 		case err := <-operatorSetUpdateSub.Err():
-			b.logger.Error("Error in websocket subscription", "err", err)
+			b.logger.Error("Operator set update subscription error", "err", err)
 			operatorSetUpdateSub.Unsubscribe()
-			operatorSetUpdateSub, err = avsSubscriber.SubscribeToOperatorSetUpdates(operatorSetUpdatedChan)
-			if err != nil {
-				b.logger.Error("Error re-subscribing to operator set updates", "err", err)
-				close(operatorSetUpdatedChan)
-				return
-			}
-
-			continue
+			close(operatorSetUpdatedChan)
+			return
 		case event := <-operatorSetUpdatedChan:
 			b.logger.Info("Received operator set update", "id", event.Id)
 

--- a/operator/attestor/attestor.go
+++ b/operator/attestor/attestor.go
@@ -200,6 +200,8 @@ func (attestor *Attestor) processRollupHeaders(rollupId uint32, headersC chan *e
 		select {
 		case <-subscription.Err():
 			attestor.logger.Error("Header subscription error", "rollupId", rollupId)
+			subscription.Unsubscribe()
+			close(headersC)
 			return
 		case header, ok := <-headersC:
 			if !ok {

--- a/operator/attestor/attestor.go
+++ b/operator/attestor/attestor.go
@@ -198,8 +198,8 @@ func (attestor *Attestor) processMQBlocks(ctx context.Context) {
 func (attestor *Attestor) processRollupHeaders(rollupId uint32, headersC chan *ethtypes.Header, subscription ethereum.Subscription, ctx context.Context) {
 	for {
 		select {
-		case <-subscription.Err():
-			attestor.logger.Error("Header subscription error", "rollupId", rollupId)
+		case err := <-subscription.Err():
+			attestor.logger.Error("Header subscription error", "rollupId", rollupId, "err", err)
 			subscription.Unsubscribe()
 			close(headersC)
 			return

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -160,7 +160,9 @@ func (r *Relayer) listenToBlocks(ctx context.Context, blockBatchC chan []*ethtyp
 	for {
 		select {
 		case err := <-sub.Err():
-			r.logger.Error("Error on rollup block subscription", "err", err)
+			r.logger.Error("Rollup block subscription error", "err", err)
+			sub.Unsubscribe()
+			close(headers)
 			return
 		case header := <-headers:
 			r.logger.Info("Received rollup block header", "number", header.Number.Uint64())


### PR DESCRIPTION
Now that all our subscriptions are made through a `SafeEthClient`, the only situations in which there is a subscription error are either when the client is being closed or the context is ended - both cases mean deliberately exiting (and in our case program exit). So, we can just standardize unsubbing and (if receiver) closing the channel whenever there is an error.
Ideally none of these steps would be necessary and are functionally changing anything if we assume the unsubbing has already happened and the channel can be closed automatically on GC, but if there ever is some extra reason at least we're not leaking anything.