### PR TITLE
Fix first header subscription using non-proxy channel

### DIFF
--- a/core/safeclient/client.go
+++ b/core/safeclient/client.go
@@ -315,7 +315,9 @@ func (c *SafeEthClient) Close() {
 }
 
 func (c *SafeEthClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
-	newSub, err := c.Client.SubscribeNewHead(ctx, ch)
+	proxyC := make(chan *types.Header, 100)
+
+	newSub, err := c.Client.SubscribeNewHead(ctx, proxyC)
 	if err != nil {
 		c.logger.Error("Failed to subscribe to new heads", "err", err)
 		return nil, err
@@ -323,7 +325,6 @@ func (c *SafeEthClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.H
 	c.logger.Info("Subscribed to new heads")
 
 	safeSub := NewSafeSubscription(newSub)
-	proxyC := make(chan *types.Header, 100)
 
 	resub := func() error {
 		newSub, err := c.Client.SubscribeNewHead(ctx, proxyC)


### PR DESCRIPTION
Was reviewing and re-testing and noticed the proxy channel is not used on the first `SubscribeNewHead` call. This is not too problematic as a new sub will be made right after and everything will work as intended, but should be fixed anyway.