### PR TITLE
Fix plugin registration and add registration int test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,6 +43,16 @@ jobs:
           cache-from: type=gha,scope=relayer
           cache-to: type=gha,mode=max,scope=relayer
 
+      - name: Build plugin container
+        uses: docker/build-push-action@v5
+        with:
+          load: true
+          context: .
+          file: ./plugin/cmd/Dockerfile
+          tags: near-sffl-operator-plugin
+          cache-from: type=gha,scope=plugin
+          cache-to: type=gha,mode=max,scope=plugin
+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -123,4 +123,5 @@ tests-contract: ## runs all forge tests
 
 tests-integration: ## runs all integration tests
 	go test ./tests/integration/integration_test.go -v -count=1
+	go test ./tests/integration/registration_test.go -v -count=1
 

--- a/config-files/plugin.anvil.yaml
+++ b/config-files/plugin.anvil.yaml
@@ -7,8 +7,8 @@ avs_registry_coordinator_address: 0x8f86403A4DE0BB5791fa46B8e795C547942fE4Cf
 operator_state_retriever_address: 0x4c5859f0F772848b2D91F1D83E2Fe57935348029
 
 # AVS network RPCs
-eth_rpc_url: http://localhost:8545
-eth_ws_url: ws://localhost:8545
+eth_rpc_url: http://mainnet-anvil:8545
+eth_ws_url: ws://mainnet-anvil:8545
 
 # EigenLayer ECDSA and BLS private key paths
 ecdsa_private_key_store_path: /near-sffl/keys/ecdsa/1/key.json

--- a/config-files/plugin.anvil.yaml
+++ b/config-files/plugin.anvil.yaml
@@ -1,0 +1,15 @@
+
+# Operator ECDSA address
+operator_address: 0xD5A0359da7B310917d7760385516B2426E86ab7f
+
+# AVS contract addresses
+avs_registry_coordinator_address: 0x8f86403A4DE0BB5791fa46B8e795C547942fE4Cf
+operator_state_retriever_address: 0x4c5859f0F772848b2D91F1D83E2Fe57935348029
+
+# AVS network RPCs
+eth_rpc_url: http://localhost:8545
+eth_ws_url: ws://localhost:8545
+
+# EigenLayer ECDSA and BLS private key paths
+ecdsa_private_key_store_path: /near-sffl/keys/ecdsa/1/key.json
+bls_private_key_store_path: /near-sffl/keys/bls/1/key.json

--- a/plugin/cmd/main.go
+++ b/plugin/cmd/main.go
@@ -62,11 +62,11 @@ func main() {
 		operationType := ctx.GlobalString(OperationFlag.Name)
 		switch operationType {
 		case "opt-in":
-			return operatorPlugin.OptIn()
+			return operatorPlugin.OptIn(ctx)
 		case "opt-out":
-			return operatorPlugin.OptOut()
+			return operatorPlugin.OptOut(ctx)
 		case "deposit":
-			return operatorPlugin.Deposit()
+			return operatorPlugin.Deposit(ctx)
 		default:
 			return cli.NewExitError(fmt.Sprintf("Invalid operation type: %v", operationType), 1)
 		}

--- a/plugin/cmd/operator_plugin.go
+++ b/plugin/cmd/operator_plugin.go
@@ -57,7 +57,7 @@ func NewOperatorPluginFromCLIContext(ctx *cli.Context) (*CliOperatorPlugin, erro
 		RegistryCoordinatorAddr:    avsConfig.AVSRegistryCoordinatorAddress,
 		OperatorStateRetrieverAddr: avsConfig.OperatorStateRetrieverAddress,
 		AvsName:                    "super-fast-finality-layer",
-		PromMetricsIpPortAddress:   avsConfig.EigenMetricsIpPortAddress,
+		PromMetricsIpPortAddress:   "127.0.0.1:9090",
 	}
 
 	ethHttpClient, err := eth.NewClient(avsConfig.EthRpcUrl)

--- a/plugin/cmd/operator_plugin.go
+++ b/plugin/cmd/operator_plugin.go
@@ -31,17 +31,8 @@ type CliOperatorPlugin struct {
 	avsReader        *chainio.AvsReader
 	avsWriter        *chainio.AvsWriter
 
-	ctx    *cli.Context
 	logger logging.Logger
 }
-
-type OperatorPlugin interface {
-	OptIn() error
-	OptOut() error
-	Deposit() error
-}
-
-var _ OperatorPlugin = &CliOperatorPlugin{}
 
 func NewOperatorPluginFromCLIContext(ctx *cli.Context) (*CliOperatorPlugin, error) {
 	goCtx := context.Background()
@@ -149,8 +140,8 @@ func NewOperatorPluginFromCLIContext(ctx *cli.Context) (*CliOperatorPlugin, erro
 	}, nil
 }
 
-func (o *CliOperatorPlugin) OptIn() error {
-	blsKeyPassword := o.ctx.GlobalString(BlsKeyPasswordFlag.Name)
+func (o *CliOperatorPlugin) OptIn(ctx *cli.Context) error {
+	blsKeyPassword := ctx.GlobalString(BlsKeyPasswordFlag.Name)
 
 	blsKeypair, err := bls.ReadPrivateKeyFromFile(o.avsConfig.BlsPrivateKeyStorePath, blsKeyPassword)
 	if err != nil {
@@ -176,8 +167,8 @@ func (o *CliOperatorPlugin) OptIn() error {
 	return nil
 }
 
-func (o *CliOperatorPlugin) OptOut() error {
-	blsKeyPassword := o.ctx.GlobalString(BlsKeyPasswordFlag.Name)
+func (o *CliOperatorPlugin) OptOut(ctx *cli.Context) error {
+	blsKeyPassword := ctx.GlobalString(BlsKeyPasswordFlag.Name)
 
 	blsKeypair, err := bls.ReadPrivateKeyFromFile(o.avsConfig.BlsPrivateKeyStorePath, blsKeyPassword)
 	if err != nil {
@@ -194,14 +185,14 @@ func (o *CliOperatorPlugin) OptOut() error {
 	return nil
 }
 
-func (o *CliOperatorPlugin) Deposit() error {
-	strategy := o.ctx.GlobalString(StrategyAddrFlag.Name)
+func (o *CliOperatorPlugin) Deposit(ctx *cli.Context) error {
+	strategy := ctx.GlobalString(StrategyAddrFlag.Name)
 	if len(strategy) == 0 {
 		o.logger.Error("Strategy address is required for deposit operation")
 		return errors.New("strategy address is required for deposit operation")
 	}
 
-	strategyAddr := common.HexToAddress(o.ctx.GlobalString(StrategyAddrFlag.Name))
+	strategyAddr := common.HexToAddress(ctx.GlobalString(StrategyAddrFlag.Name))
 	_, tokenAddr, err := o.clients.ElChainReader.GetStrategyAndUnderlyingToken(&bind.CallOpts{}, strategyAddr)
 	if err != nil {
 		o.logger.Error("Failed to fetch strategy contract", "err", err)

--- a/tests/integration/registration_test.go
+++ b/tests/integration/registration_test.go
@@ -116,7 +116,7 @@ func TestRegistration(t *testing.T) {
 		t.Fatal("Operator should not be registered after opting out")
 	}
 
-	defer func() {
+	cleanup := func() {
 		if err := mainnetAnvil.Container.Terminate(ctx); err != nil {
 			t.Fatalf("Error terminating container: %s", err.Error())
 		}
@@ -132,10 +132,10 @@ func TestRegistration(t *testing.T) {
 		}
 
 		cancel()
-	}()
+	}
 
 	t.Log("Done")
-	<-ctx.Done()
+	cleanup()
 }
 
 func runOperatorPluginContainer(t *testing.T, ctx context.Context, name, networkName, operation, ecdsaPassword, blsPassword string) testcontainers.Container {

--- a/tests/integration/registration_test.go
+++ b/tests/integration/registration_test.go
@@ -1,0 +1,150 @@
+package integration
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	sdkutils "github.com/Layr-Labs/eigensdk-go/utils"
+	"github.com/NethermindEth/near-sffl/core/chainio"
+	optypes "github.com/NethermindEth/near-sffl/operator/types"
+	"github.com/NethermindEth/near-sffl/tests/integration/utils"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func TestRegistration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+
+	logger, err := logging.NewZapLogger(logging.Development)
+	if err != nil {
+		t.Fatalf("Failed to create logger: %s", err.Error())
+	}
+
+	networkName := "near-sffl-registration"
+	net, err := testcontainers.GenericNetwork(ctx, testcontainers.GenericNetworkRequest{
+		NetworkRequest: testcontainers.NetworkRequest{
+			Driver:         "bridge",
+			Name:           networkName,
+			CheckDuplicate: true,
+			Attachable:     true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Cannot create network: %s", err.Error())
+	}
+
+	mainnetAnvilContainerName := "mainnet-anvil"
+	pluginContainerName := "plugin"
+
+	mainnetAnvil := utils.StartAnvilTestContainer(t, ctx, mainnetAnvilContainerName, "8545", "1", true, networkName)
+
+	nodeConfig := optypes.NodeConfig{}
+	nodeConfigFilePath := "../../config-files/plugin.anvil.yaml"
+	err = sdkutils.ReadYamlConfig(nodeConfigFilePath, &nodeConfig)
+	if err != nil {
+		t.Fatalf("Failed to read yaml config: %s", err.Error())
+	}
+
+	avsReader, err := chainio.BuildAvsReader(common.HexToAddress(nodeConfig.AVSRegistryCoordinatorAddress), common.HexToAddress(nodeConfig.OperatorStateRetrieverAddress), mainnetAnvil.HttpClient, logger)
+	if err != nil {
+		t.Fatalf("Error building avs reader: %s", err.Error())
+	}
+
+	blsPassword, err := os.ReadFile(path.Dir(nodeConfig.BlsPrivateKeyStorePath) + "/password.txt")
+	if err != nil {
+		t.Fatalf("Error reading bls password: %s", err.Error())
+	}
+
+	ecdsaPassword, err := os.ReadFile(path.Dir(nodeConfig.EcdsaPrivateKeyStorePath) + "/password.txt")
+	if err != nil {
+		t.Fatalf("Error reading ecdsa password: %s", err.Error())
+	}
+
+	operatorPluginContainerOptIn := runOperatorPluginContainer(t, ctx, pluginContainerName, networkName, "opt-in", string(ecdsaPassword), string(blsPassword))
+
+	isOperatorRegistered, err := avsReader.IsOperatorRegistered(&bind.CallOpts{}, common.HexToAddress(nodeConfig.OperatorAddress))
+	if err != nil {
+		t.Fatalf("Error checking if operator is registered: %s", err.Error())
+	}
+
+	if !isOperatorRegistered {
+		t.Fatal("Operator should be registered after opting in")
+	}
+
+	operatorPluginContainerOptOut := runOperatorPluginContainer(t, ctx, pluginContainerName, networkName, "opt-out", string(ecdsaPassword), string(blsPassword))
+
+	isOperatorRegistered, err = avsReader.IsOperatorRegistered(&bind.CallOpts{}, common.HexToAddress(nodeConfig.OperatorAddress))
+	if err != nil {
+		t.Fatalf("Error checking if operator is registered: %s", err.Error())
+	}
+
+	if isOperatorRegistered {
+		t.Fatal("Operator should not be registered after opting out")
+	}
+
+	defer func() {
+		if err := mainnetAnvil.Container.Terminate(ctx); err != nil {
+			t.Fatalf("Error terminating container: %s", err.Error())
+		}
+		if err := operatorPluginContainerOptIn.Terminate(ctx); err != nil {
+			t.Fatalf("Error terminating container: %s", err.Error())
+		}
+		if err := operatorPluginContainerOptOut.Terminate(ctx); err != nil {
+			t.Fatalf("Error terminating container: %s", err.Error())
+		}
+
+		if err := net.Remove(ctx); err != nil {
+			t.Fatalf("Error removing network: %s", err.Error())
+		}
+
+		cancel()
+	}()
+
+	t.Log("Done")
+	<-ctx.Done()
+}
+
+func runOperatorPluginContainer(t *testing.T, ctx context.Context, name, networkName, operation, ecdsaPassword, blsPassword string) testcontainers.Container {
+	req := testcontainers.ContainerRequest{
+		Image:    "near-sffl-operator-plugin",
+		Name:     name,
+		Networks: []string{networkName},
+		Env: map[string]string{
+			"ECDSA_KEY_PASSWORD": ecdsaPassword,
+			"BLS_KEY_PASSWORD":   blsPassword,
+		},
+		Files: []testcontainers.ContainerFile{
+			{
+				HostFilePath:      "../../config-files/plugin.anvil.yaml",
+				ContainerFilePath: "/near-sffl/config.yml",
+			},
+			{
+				HostFilePath:      "../../tests/keys/ecdsa/1/key.json",
+				ContainerFilePath: "/near-sffl/keys/ecdsa.json",
+			},
+			{
+				HostFilePath:      "../../tests/keys/bls/1/key.json",
+				ContainerFilePath: "/near-sffl/keys/bls.json",
+			},
+		},
+		WaitingFor: wait.ForExit(),
+	}
+
+	genericReq := testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, genericReq)
+	if err != nil {
+		t.Fatalf("Error starting operator plugin container: %s", err.Error())
+	}
+
+	return container
+}


### PR DESCRIPTION
Something that passed us by on #171 - the plugin receivers considered the context would be part of the struct, but it wasn't being assigned on the constructor. For now, I removed the interface, as we're not having much use for it, and made it so the receivers get the context. Saving contexts is a bit weird, so I think this is for the best, and we can get a common interface later.
I also added an integration test for opt-in/opt-out operations.

It's important to merge this quickly so we have registering working.