### PR TITLE
Prefer tags for logging

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -121,7 +121,7 @@ func NewAggregator(ctx context.Context, config *config.Config, logger logging.Lo
 	}
 	clients, err := eigenclients.BuildAll(chainioConfig, config.EcdsaPrivateKey, logger)
 	if err != nil {
-		logger.Errorf("Cannot create sdk clients", "err", err)
+		logger.Error("Cannot create sdk clients", "err", err)
 		return nil, err
 	}
 	registry := clients.PrometheusRegistry
@@ -134,7 +134,7 @@ func NewAggregator(ctx context.Context, config *config.Config, logger logging.Lo
 		logger,
 	)
 	if err != nil {
-		logger.Errorf("Cannot create http ethclient", "err", err)
+		logger.Error("Cannot create http ethclient", "err", err)
 		return nil, err
 	}
 
@@ -146,7 +146,7 @@ func NewAggregator(ctx context.Context, config *config.Config, logger logging.Lo
 		logger,
 	)
 	if err != nil {
-		logger.Errorf("Cannot create ws ethclient", "err", err)
+		logger.Error("Cannot create ws ethclient", "err", err)
 		return nil, err
 	}
 
@@ -178,7 +178,7 @@ func NewAggregator(ctx context.Context, config *config.Config, logger logging.Lo
 
 	avsWriter, err := chainio.BuildAvsWriterFromConfig(txMgr, config, ethHttpClient, logger)
 	if err != nil {
-		logger.Errorf("Cannot create avsWriter", "err", err)
+		logger.Error("Cannot create avsWriter", "err", err)
 		return nil, err
 	}
 
@@ -190,7 +190,7 @@ func NewAggregator(ctx context.Context, config *config.Config, logger logging.Lo
 
 	msgDb, err := database.NewDatabase(config.AggregatorDatabasePath)
 	if err != nil {
-		logger.Errorf("Cannot create database", "err", err)
+		logger.Error("Cannot create database", "err", err)
 		return nil, err
 	}
 
@@ -270,20 +270,20 @@ func (agg *Aggregator) EnableMetrics(registry *prometheus.Registry) error {
 }
 
 func (agg *Aggregator) Start(ctx context.Context) error {
-	agg.logger.Infof("Starting aggregator.")
+	agg.logger.Info("Starting aggregator.")
 
 	if agg.metrics != nil {
 		agg.metrics.Start(ctx, agg.registry)
 	}
 
-	agg.logger.Infof("Starting aggregator rpc server.")
+	agg.logger.Info("Starting aggregator rpc server.")
 	go agg.startServer()
 
-	agg.logger.Infof("Starting aggregator REST API.")
+	agg.logger.Info("Starting aggregator REST API.")
 	go agg.startRestServer()
 
 	ticker := time.NewTicker(agg.checkpointInterval)
-	agg.logger.Infof("Aggregator set to send new task every %s...", agg.checkpointInterval.String())
+	agg.logger.Info("Aggregator set to send new task", "interval", agg.checkpointInterval.String())
 	defer ticker.Stop()
 
 	broadcasterErrorChan := agg.rollupBroadcaster.GetErrorChan()
@@ -355,7 +355,7 @@ func (agg *Aggregator) sendAggregatedResponseToContract(blsAggServiceResp blsagg
 
 	currentBlock, err := agg.httpClient.BlockNumber(context.Background())
 	if err != nil {
-		agg.logger.Errorf("Error getting current block number", "err", err)
+		agg.logger.Error("Error getting current block number", "err", err)
 		return
 	}
 

--- a/aggregator/message_blsagg.go
+++ b/aggregator/message_blsagg.go
@@ -470,7 +470,7 @@ func (mbas *MessageBlsAggregatorService) verifySignature(
 ) error {
 	_, ok := operatorsAvsStateDict[signedMessageDigest.OperatorId]
 	if !ok {
-		mbas.logger.Warn("Operatornot found. Skipping message", "operator", fmt.Sprintf("%#v", signedMessageDigest.OperatorId))
+		mbas.logger.Warn("Operator not found. Skipping message", "operator", fmt.Sprintf("%#v", signedMessageDigest.OperatorId))
 		return OperatorNotPartOfMessageQuorumErrorFn(signedMessageDigest.OperatorId, signedMessageDigest.MessageDigest)
 	}
 

--- a/aggregator/message_blsagg.go
+++ b/aggregator/message_blsagg.go
@@ -470,7 +470,7 @@ func (mbas *MessageBlsAggregatorService) verifySignature(
 ) error {
 	_, ok := operatorsAvsStateDict[signedMessageDigest.OperatorId]
 	if !ok {
-		mbas.logger.Warnf("Operator %#v not found. Skipping message.", signedMessageDigest.OperatorId)
+		mbas.logger.Warn("Operatornot found. Skipping message", "operator", fmt.Sprintf("%#v", signedMessageDigest.OperatorId))
 		return OperatorNotPartOfMessageQuorumErrorFn(signedMessageDigest.OperatorId, signedMessageDigest.MessageDigest)
 	}
 

--- a/aggregator/rpc_server.go
+++ b/aggregator/rpc_server.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/rpc"
 	"strings"
@@ -43,7 +44,7 @@ func (agg *Aggregator) startServer() error {
 // reply doesn't need to be checked. If there are no errors, the task response is accepted
 // rpc framework forces a reply type to exist, so we put bool as a placeholder
 func (agg *Aggregator) ProcessSignedCheckpointTaskResponse(signedCheckpointTaskResponse *messages.SignedCheckpointTaskResponse, reply *bool) error {
-	agg.logger.Infof("Received signed task response: %#v", signedCheckpointTaskResponse)
+	agg.logger.Info("Received signed task response", "response", fmt.Sprintf("%#v", signedCheckpointTaskResponse))
 
 	taskIndex := signedCheckpointTaskResponse.TaskResponse.ReferenceTaskIndex
 	taskResponseDigest, err := signedCheckpointTaskResponse.TaskResponse.Digest()
@@ -93,7 +94,7 @@ func (agg *Aggregator) ProcessSignedStateRootUpdateMessage(signedStateRootUpdate
 	operatorId := signedStateRootUpdateMessage.OperatorId
 	rollupId := signedStateRootUpdateMessage.Message.RollupId
 
-	agg.logger.Infof("Received signed state root update message: %#v %#v", signedStateRootUpdateMessage, messageDigest)
+	agg.logger.Info("Received signed state root update message", "updateMessage", fmt.Sprintf("%#v", signedStateRootUpdateMessage) , "messageDigest", fmt.Sprintf("%#v", messageDigest))
 
 	agg.rpcListener.IncTotalSignedCheckpointTaskResponse()
 	agg.rpcListener.ObserveLastMessageReceivedTime(operatorId, StateRootUpdateMessageLabel)
@@ -138,7 +139,7 @@ func (agg *Aggregator) ProcessSignedOperatorSetUpdateMessage(signedOperatorSetUp
 
 	operatorId := signedOperatorSetUpdateMessage.OperatorId
 
-	agg.logger.Infof("Received signed operator set update message: %#v", signedOperatorSetUpdateMessage)
+	agg.logger.Info("Received signed operator set update message", "message", fmt.Sprintf("%#v", signedOperatorSetUpdateMessage))
 
 	agg.rpcListener.IncTotalSignedOperatorSetUpdateMessage()
 	agg.rpcListener.ObserveLastMessageReceivedTime(operatorId, OperatorSetUpdateMessageLabel)

--- a/cli/actions/register_operator_with_avs.go
+++ b/cli/actions/register_operator_with_avs.go
@@ -24,7 +24,7 @@ func RegisterOperatorWithAvs(ctx *cli.Context) error {
 
 	ecdsaKeyPassword, ok := os.LookupEnv("OPERATOR_ECDSA_KEY_PASSWORD")
 	if !ok {
-		log.Printf("OPERATOR_ECDSA_KEY_PASSWORD env var not set. using empty string")
+		log.Print("OPERATOR_ECDSA_KEY_PASSWORD env var not set. using empty string")
 	}
 	operatorEcdsaPrivKey, err := sdkecdsa.ReadKey(
 		nodeConfig.EcdsaPrivateKeyStorePath,

--- a/core/chainio/avs_subscriber.go
+++ b/core/chainio/avs_subscriber.go
@@ -32,7 +32,7 @@ type AvsSubscriber struct {
 func BuildAvsSubscriber(registryCoordinatorAddr, blsOperatorStateRetrieverAddr gethcommon.Address, ethclient eth.Client, logger sdklogging.Logger) (*AvsSubscriber, error) {
 	avsContractBindings, err := NewAvsManagersBindings(registryCoordinatorAddr, blsOperatorStateRetrieverAddr, ethclient, logger)
 	if err != nil {
-		logger.Errorf("Failed to create contract bindings", "err", err)
+		logger.Error("Failed to create contract bindings", "err", err)
 		return nil, err
 	}
 	return NewAvsSubscriber(avsContractBindings, logger), nil
@@ -53,7 +53,7 @@ func (s *AvsSubscriber) SubscribeToNewTasks(checkpointTaskCreatedChan chan *task
 		s.logger.Error("Failed to subscribe to new TaskManager tasks", "err", err)
 		return nil, err
 	}
-	s.logger.Infof("Subscribed to new TaskManager tasks")
+	s.logger.Info("Subscribed to new TaskManager tasks")
 	return sub, nil
 }
 
@@ -65,7 +65,7 @@ func (s *AvsSubscriber) SubscribeToTaskResponses(taskResponseChan chan *taskmana
 		s.logger.Error("Failed to subscribe to CheckpointTaskResponded events", "err", err)
 		return nil, err
 	}
-	s.logger.Infof("Subscribed to CheckpointTaskResponded events")
+	s.logger.Info("Subscribed to CheckpointTaskResponded events")
 	return sub, nil
 }
 
@@ -81,6 +81,6 @@ func (s *AvsSubscriber) SubscribeToOperatorSetUpdates(operatorSetUpdateChan chan
 		s.logger.Error("Failed to subscribe to OperatorSetUpdatedAtBlock events", "err", err)
 		return nil, err
 	}
-	s.logger.Infof("Subscribed to OperatorSetUpdatedAtBlock events")
+	s.logger.Info("Subscribed to OperatorSetUpdatedAtBlock events")
 	return sub, nil
 }

--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -80,17 +80,17 @@ func NewAvsWriter(avsRegistryWriter avsregistry.AvsRegistryWriter, avsServiceBin
 func (w *AvsWriter) SendNewCheckpointTask(ctx context.Context, fromTimestamp uint64, toTimestamp uint64, quorumThreshold eigentypes.QuorumThresholdPercentage, quorumNumbers eigentypes.QuorumNums) (taskmanager.CheckpointTask, uint32, error) {
 	txOpts, err := w.TxMgr.GetNoSendTxOpts()
 	if err != nil {
-		w.logger.Errorf("Error getting tx opts")
+		w.logger.Error("Error getting tx opts")
 		return taskmanager.CheckpointTask{}, 0, err
 	}
 	tx, err := w.AvsContractBindings.TaskManager.CreateCheckpointTask(txOpts, fromTimestamp, toTimestamp, uint32(quorumThreshold), quorumNumbers.UnderlyingType())
 	if err != nil {
-		w.logger.Errorf("Error assembling CreateCheckpointTask tx")
+		w.logger.Error("Error assembling CreateCheckpointTask tx")
 		return taskmanager.CheckpointTask{}, 0, err
 	}
 	receipt, err := w.TxMgr.Send(ctx, tx)
 	if err != nil {
-		w.logger.Errorf("Error submitting CreateCheckpointTask tx")
+		w.logger.Error("Error submitting CreateCheckpointTask tx")
 		return taskmanager.CheckpointTask{}, 0, err
 	}
 	checkpointTaskCreatedEvent, err := w.AvsContractBindings.TaskManager.ContractSFFLTaskManagerFilterer.ParseCheckpointTaskCreated(*receipt.Logs[0])
@@ -108,7 +108,7 @@ func (w *AvsWriter) SendAggregatedResponse(
 ) (*types.Receipt, error) {
 	txOpts, err := w.TxMgr.GetNoSendTxOpts()
 	if err != nil {
-		w.logger.Errorf("Error getting tx opts")
+		w.logger.Error("Error getting tx opts")
 		return nil, err
 	}
 
@@ -120,7 +120,7 @@ func (w *AvsWriter) SendAggregatedResponse(
 
 	receipt, err := w.TxMgr.Send(ctx, tx)
 	if err != nil {
-		w.logger.Errorf("Error submitting CreateCheckpointTask tx")
+		w.logger.Error("Error submitting CreateCheckpointTask tx")
 		return nil, err
 	}
 	return receipt, nil
@@ -135,17 +135,17 @@ func (w *AvsWriter) RaiseChallenge(
 ) (*types.Receipt, error) {
 	txOpts, err := w.TxMgr.GetNoSendTxOpts()
 	if err != nil {
-		w.logger.Errorf("Error getting tx opts")
+		w.logger.Error("Error getting tx opts")
 		return nil, err
 	}
 	tx, err := w.AvsContractBindings.TaskManager.RaiseAndResolveCheckpointChallenge(txOpts, task, taskResponse.ToBinding(), taskResponseMetadata, pubkeysOfNonSigningOperators)
 	if err != nil {
-		w.logger.Errorf("Error assembling RaiseChallenge tx")
+		w.logger.Error("Error assembling RaiseChallenge tx")
 		return nil, err
 	}
 	receipt, err := w.TxMgr.Send(ctx, tx)
 	if err != nil {
-		w.logger.Errorf("Error submitting CreateCheckpointTask tx")
+		w.logger.Error("Error submitting CreateCheckpointTask tx")
 		return nil, err
 	}
 	return receipt, nil

--- a/operator/attestor/attestor.go
+++ b/operator/attestor/attestor.go
@@ -171,7 +171,7 @@ func (attestor *Attestor) processMQBlocks(ctx context.Context) {
 			attestor.logger.Info("Notifying", "rollupId", mqBlock.RollupId, "height", mqBlock.Block.Header().Number.Uint64())
 			err := attestor.notifier.Notify(mqBlock.RollupId, mqBlock)
 			if err != nil {
-				attestor.logger.Error("notifier", "err", err)
+				attestor.logger.Error("Notifier", "err", err)
 			}
 
 			// Rebroadcast in case mq block arrives first

--- a/operator/attestor/attestor.go
+++ b/operator/attestor/attestor.go
@@ -134,13 +134,13 @@ func (attestor *Attestor) Start(ctx context.Context) error {
 		headersC := make(chan *ethtypes.Header, 100)
 		subscription, err := client.SubscribeNewHead(ctx, headersC)
 		if err != nil {
-			attestor.logger.Fatalf("Failed to subscribe to new header: %v, for rollupId: %v", err, rollupId)
+			attestor.logger.Fatal("Failed to subscribe to new header", "err", err, "rollupId", rollupId)
 			return err
 		}
 
 		blockNumber, err := client.BlockNumber(ctx)
 		if err != nil {
-			attestor.logger.Fatalf("Failed to get block number: %v, for rollupId: %v", err, rollupId)
+			attestor.logger.Fatal("Failed to get block number", "err", err, "rollupId", rollupId)
 			return err
 		}
 
@@ -171,7 +171,7 @@ func (attestor *Attestor) processMQBlocks(ctx context.Context) {
 			attestor.logger.Info("Notifying", "rollupId", mqBlock.RollupId, "height", mqBlock.Block.Header().Number.Uint64())
 			err := attestor.notifier.Notify(mqBlock.RollupId, mqBlock)
 			if err != nil {
-				attestor.logger.Errorf("Notifier: %v", err)
+				attestor.logger.Error("notifier", "err", err)
 			}
 
 			// Rebroadcast in case mq block arrives first
@@ -229,7 +229,7 @@ func (attestor *Attestor) processHeader(rollupId uint32, rollupHeader *ethtypes.
 
 	predicate := func(mqBlock consumer.BlockData) bool {
 		if mqBlock.RollupId != rollupId {
-			attestor.logger.Warnf("Subscriber expected rollupId: %v, but got %v", rollupId, mqBlock.RollupId)
+			attestor.logger.Warn("Subscriber rollupId mismatch", "expected", rollupId, "actual", mqBlock.RollupId)
 			return false
 		}
 
@@ -238,7 +238,7 @@ func (attestor *Attestor) processHeader(rollupId uint32, rollupHeader *ethtypes.
 		}
 
 		if mqBlock.Block.Header().Root != rollupHeader.Root {
-			attestor.logger.Warnf("StateRoot from MQ doesn't match one from Node")
+			attestor.logger.Warn("StateRoot from MQ doesn't match one from Node")
 			attestor.listener.OnBlockMismatch(rollupId)
 
 			return false

--- a/operator/avs_manager.go
+++ b/operator/avs_manager.go
@@ -172,7 +172,7 @@ func (avsManager *AvsManager) Start(ctx context.Context, operatorAddr common.Add
 func (avsManager *AvsManager) handleOperatorSetUpdate(ctx context.Context, data *opsetupdatereg.ContractSFFLOperatorSetUpdateRegistryOperatorSetUpdatedAtBlock) error {
 	operatorSetDelta, err := avsManager.avsReader.GetOperatorSetUpdateDelta(ctx, data.Id)
 	if err != nil {
-		avsManager.logger.Errorf("Couldn't get Operator set update delta: %v for block: %v", err, data.Id)
+		avsManager.logger.Error("Couldn't get Operator set update delta", "err", err, "block", data.Id)
 		return err
 	}
 
@@ -208,18 +208,18 @@ func (avsManager *AvsManager) DepositIntoStrategy(operatorAddr common.Address, s
 	txOpts, err := avsManager.avsWriter.TxMgr.GetNoSendTxOpts()
 	tx, err := contractErc20Mock.Mint(txOpts, operatorAddr, amount)
 	if err != nil {
-		avsManager.logger.Errorf("Error assembling Mint tx")
+		avsManager.logger.Error("Error assembling Mint tx")
 		return err
 	}
 	_, err = avsManager.avsWriter.TxMgr.Send(context.Background(), tx)
 	if err != nil {
-		avsManager.logger.Errorf("Error submitting Mint tx")
+		avsManager.logger.Error("Error submitting Mint tx")
 		return err
 	}
 
 	_, err = avsManager.eigenlayerWriter.DepositERC20IntoStrategy(context.Background(), strategyAddr, amount)
 	if err != nil {
-		avsManager.logger.Errorf("Error depositing into strategy", "err", err)
+		avsManager.logger.Error("Error depositing into strategy", "err", err)
 		return err
 	}
 	return nil
@@ -232,7 +232,7 @@ func (avsManager *AvsManager) RegisterOperatorWithEigenlayer(operatorAddr common
 	}
 	_, err := avsManager.eigenlayerWriter.RegisterAsOperator(context.Background(), operator)
 	if err != nil {
-		avsManager.logger.Errorf("Error registering operator with eigenlayer")
+		avsManager.logger.Error("Error registering operator with eigenlayer")
 		return err
 	}
 
@@ -250,13 +250,13 @@ func (avsManager *AvsManager) RegisterOperatorWithAvs(
 	socket := "Not Needed"
 	curBlockNum, err := client.BlockNumber(context.Background())
 	if err != nil {
-		avsManager.logger.Errorf("Unable to get current block number")
+		avsManager.logger.Error("Unable to get current block number")
 		return err
 	}
 
 	curBlock, err := client.BlockByNumber(context.Background(), big.NewInt(int64(curBlockNum)))
 	if err != nil {
-		avsManager.logger.Errorf("Unable to get current block")
+		avsManager.logger.Error("Unable to get current block")
 		return err
 	}
 
@@ -273,10 +273,10 @@ func (avsManager *AvsManager) RegisterOperatorWithAvs(
 	)
 
 	if err != nil {
-		avsManager.logger.Errorf("Unable to register operator with avs registry coordinator")
+		avsManager.logger.Error("Unable to register operator with avs registry coordinator")
 		return err
 	}
-	avsManager.logger.Infof("Registered operator with avs registry coordinator.")
+	avsManager.logger.Info("Registered operator with avs registry coordinator.")
 
 	return nil
 }

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -94,12 +94,12 @@ func NewOperatorFromConfig(c optypes.NodeConfig) (*Operator, error) {
 	nodeApi := nodeapi.NewNodeApi(AVS_NAME, SEM_VER, c.NodeApiIpPortAddress, logger)
 	blsKeyPassword, ok := os.LookupEnv("OPERATOR_BLS_KEY_PASSWORD")
 	if !ok {
-		logger.Warnf("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
+		logger.Warn("OPERATOR_BLS_KEY_PASSWORD env var not set. using empty string")
 	}
 
 	blsKeyPair, err := bls.ReadPrivateKeyFromFile(c.BlsPrivateKeyStorePath, blsKeyPassword)
 	if err != nil {
-		logger.Errorf("Cannot parse bls private key", "err", err)
+		logger.Error("Cannot parse bls private key", "err", err)
 		return nil, err
 	}
 
@@ -107,7 +107,7 @@ func NewOperatorFromConfig(c optypes.NodeConfig) (*Operator, error) {
 
 	ecdsaKeyPassword, ok := os.LookupEnv("OPERATOR_ECDSA_KEY_PASSWORD")
 	if !ok {
-		logger.Warnf("OPERATOR_ECDSA_KEY_PASSWORD env var not set. using empty string")
+		logger.Warn("OPERATOR_ECDSA_KEY_PASSWORD env var not set. using empty string")
 	}
 
 	ecdsaPrivateKey, err := sdkecdsa.ReadKey(c.EcdsaPrivateKeyStorePath, ecdsaKeyPassword)
@@ -265,7 +265,7 @@ func (o *Operator) EnableMetrics(registry *prometheus.Registry) error {
 }
 
 func (o *Operator) Start(ctx context.Context) error {
-	o.logger.Infof("Starting operator.")
+	o.logger.Info("Starting operator.")
 
 	if o.config.EnableNodeApi {
 		o.nodeApi.Start()
@@ -473,7 +473,7 @@ func (o *Operator) registerOperatorOnStartup(
 		// This error might only be that the operator was already registered with eigenlayer, so we don't want to fatal
 		o.logger.Error("Error registering operator with eigenlayer", "err", err)
 	} else {
-		o.logger.Infof("Registered operator with eigenlayer")
+		o.logger.Info("Registered operator with eigenlayer")
 	}
 
 	if mockTokenStrategyAddr.Cmp(common.Address{}) != 0 {
@@ -483,7 +483,7 @@ func (o *Operator) registerOperatorOnStartup(
 		if err != nil {
 			o.logger.Fatal("Error depositing into strategy", "err", err)
 		}
-		o.logger.Infof("Deposited %s into strategy %s", amount, mockTokenStrategyAddr)
+		o.logger.Info("Deposited into strategy", "amount", amount, "strategy", mockTokenStrategyAddr)
 	}
 
 	isOperatorRegistered, err := o.avsManager.avsReader.IsOperatorRegistered(&bind.CallOpts{}, o.operatorAddr)
@@ -496,9 +496,9 @@ func (o *Operator) registerOperatorOnStartup(
 		if err != nil {
 			o.logger.Fatal("Error registering operator with avs", "err", err)
 		}
-		o.logger.Infof("Registered operator with avs")
+		o.logger.Info("Registered operator with avs")
 	} else {
-		o.logger.Infof("Operator already registered with avs")
+		o.logger.Info("Operator already registered with avs")
 	}
 }
 

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -265,7 +265,7 @@ func (o *Operator) EnableMetrics(registry *prometheus.Registry) error {
 }
 
 func (o *Operator) Start(ctx context.Context) error {
-	o.logger.Info("Starting operator.")
+	o.logger.Info("Starting operator")
 
 	if o.config.EnableNodeApi {
 		o.nodeApi.Start()

--- a/relayer/cmd/main.go
+++ b/relayer/cmd/main.go
@@ -120,7 +120,7 @@ func relayerMain(config config.RelayerConfig) error {
 			logger.Fatal(err.Error())
 		}
 
-		logger.Infof("Config: %s", string(configJson))
+		logger.Info("Read config", "config", string(configJson))
 	}
 
 	logger.Info("initializing relayer")

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -151,7 +151,7 @@ func (r *Relayer) listenToBlocks(ctx context.Context, blockBatchC chan []*ethtyp
 
 	sub, err := r.rpcClient.SubscribeNewHead(ctx, headers)
 	if err != nil {
-		r.logger.Fatalf("Error subscribing to new rollup block headers: %s", err.Error())
+		r.logger.Fatal("error subscribing to new rollup block headers", "err", err.Error())
 	}
 	defer sub.Unsubscribe()
 

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -151,7 +151,7 @@ func (r *Relayer) listenToBlocks(ctx context.Context, blockBatchC chan []*ethtyp
 
 	sub, err := r.rpcClient.SubscribeNewHead(ctx, headers)
 	if err != nil {
-		r.logger.Fatal("error subscribing to new rollup block headers", "err", err.Error())
+		r.logger.Fatal("Error subscribing to new rollup block headers", "err", err.Error())
 	}
 	defer sub.Unsubscribe()
 


### PR DESCRIPTION
Resolves #179. Replaces all occurrences of formatting logging (`logger.<LEVEL>f`) for tags.

Some log statements where using formatting variants despite not leveraging formatting at all.