### PR TITLE
Remove header ticker stopping on SafeEthClient

### DIFF
--- a/core/safeclient/client.go
+++ b/core/safeclient/client.go
@@ -351,8 +351,6 @@ func (c *SafeEthClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.H
 			if err != nil {
 				c.logger.Error("Failed to resubscribe to heads", "err", err)
 				headerTicker.Reset(c.headerTimeout)
-			} else {
-				headerTicker.Stop()
 			}
 		}
 


### PR DESCRIPTION
We were stopping the header ticker once a successful resub happened, but we actually *should* leave it running because sometimes providers just stop sending blocks without an underlying error. With this, we do try to resub if there are no blocks received in that time window.