### PR TITLE
Capture `err` for proper check

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -466,7 +466,7 @@ func (agg *Aggregator) handleStateRootUpdateReachedQuorum(blsAggServiceResp type
 		agg.logger.Error("Aggregator could not store message")
 		return
 	}
-	agg.msgDb.StoreStateRootUpdateAggregation(msg, blsAggServiceResp.MessageBlsAggregation)
+	err = agg.msgDb.StoreStateRootUpdateAggregation(msg, blsAggServiceResp.MessageBlsAggregation)
 	if err != nil {
 		agg.logger.Error("Aggregator could not store message aggregation")
 		return
@@ -517,7 +517,7 @@ func (agg *Aggregator) handleOperatorSetUpdateReachedQuorum(ctx context.Context,
 		agg.logger.Error("Aggregator could not store message")
 		return
 	}
-	agg.msgDb.StoreOperatorSetUpdateAggregation(msg, blsAggServiceResp.MessageBlsAggregation)
+	err = agg.msgDb.StoreOperatorSetUpdateAggregation(msg, blsAggServiceResp.MessageBlsAggregation)
 	if err != nil {
 		agg.logger.Error("Aggregator could not store message aggregation")
 		return


### PR DESCRIPTION
There are certain cases where we are not properly setting the usual `err` variable to the latest error, making checks (`if err != nil`) useless since they're double-checking the same error.