### PR TITLE
Improve resubscription error handling

### DIFF
--- a/core/safeclient/client.go
+++ b/core/safeclient/client.go
@@ -264,8 +264,9 @@ func (c *SafeEthClient) SubscribeFilterLogs(ctx context.Context, q ethereum.Filt
 			err := resub()
 			if err != nil {
 				c.logger.Error("Failed to resubscribe to logs", "err", err)
-				ticker.Reset(c.logResubInterval)
 			}
+
+			ticker.Reset(c.logResubInterval)
 		}
 
 		for {
@@ -347,8 +348,9 @@ func (c *SafeEthClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.H
 			err := resub()
 			if err != nil {
 				c.logger.Error("Failed to resubscribe to heads", "err", err)
-				headerTicker.Reset(c.headerTimeout)
 			}
+
+			headerTicker.Reset(c.headerTimeout)
 		}
 
 		receivedBlock := false

--- a/core/safeclient/client.go
+++ b/core/safeclient/client.go
@@ -233,14 +233,13 @@ func (c *SafeEthClient) SubscribeFilterLogs(ctx context.Context, q ethereum.Filt
 		}
 		c.logger.Info("Resubscribed to logs")
 
+		safeSub.SetUnderlyingSub(newSub)
+
 		missedLogs, err := resubFilterLogs()
 		if err != nil {
 			c.logger.Error("Failed to get missed logs", "err", err)
-			newSub.Unsubscribe()
 			return err
 		}
-
-		safeSub.SetUnderlyingSub(newSub)
 
 		for _, log := range missedLogs {
 			if tryCacheLog(&log) {


### PR DESCRIPTION
This PR makes two small improvements on resubscriptions:
1. If the subscription didn't fail but the log filtering did, the underlying subscription is still changed
2. The resub ticker is reset no matter what, as in the end we're rate limiting resubs