### PR TITLE
Adjust default log filtering block range params

### DIFF
--- a/core/safeclient/client.go
+++ b/core/safeclient/client.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	BLOCK_CHUNK_SIZE   = 2000
-	BLOCK_MAX_RANGE    = 10000
+	BLOCK_CHUNK_SIZE   = 100
+	BLOCK_MAX_RANGE    = 100
 	LOG_RESUB_INTERVAL = 5 * time.Minute
 	HEADER_TIMEOUT     = 30 * time.Second
 )


### PR DESCRIPTION
This PR adjusts the default log filtering block range params to safer values based on free RPC plans. In a later PR this should become part of the operator config, but for now those are safe enough values for our uses (i.e. 100 blocks in Holesky is 1200s).