### PR TITLE
Fix `SafeEthClient` concurrent close

### DIFF
--- a/core/safeclient/client_test.go
+++ b/core/safeclient/client_test.go
@@ -389,6 +389,23 @@ func NewMockSafeClientControllable(ctx context.Context, mockCtrl *gomock.Control
 	return client, err
 }
 
+func TestConcurrentClose(t *testing.T) {
+	logger, err := logging.NewZapLogger("development")
+	assert.NoError(t, err)
+
+	client, err := safeclient.NewSafeEthClient("", logger, safeclient.WithCustomCreateClient(func(string, logging.Logger) (eth.Client, error) { return nil, nil }))
+	assert.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 1; i <= 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			client.Close()
+		}()
+	}
+}
+
 func TestSubscribeNewHead(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/core/safeclient/client_test.go
+++ b/core/safeclient/client_test.go
@@ -404,6 +404,7 @@ func TestConcurrentClose(t *testing.T) {
 			client.Close()
 		}()
 	}
+	wg.Wait()
 }
 
 func TestSubscribeNewHead(t *testing.T) {


### PR DESCRIPTION
Fixes #199 by using `sync.Once` to avoid double-closing a channel