### PR TITLE
Fix path to bls-utils

### DIFF
--- a/contracts/evm/test/utils/BLSUtilsFFI.sol
+++ b/contracts/evm/test/utils/BLSUtilsFFI.sol
@@ -52,7 +52,7 @@ contract BLSUtilsFFI is Test {
     function _ffi(string[] memory command) internal returns (bytes memory) {
         string[] memory inputs = new string[](command.length + 1);
 
-        inputs[0] = "./test/ffi/bls-utils/target/debug/bls-utils";
+        inputs[0] = "../../target/debug/bls-utils";
         for (uint256 i = 0; i < command.length; i++) {
             inputs[i + 1] = command[i];
         }


### PR DESCRIPTION
Since `bls-utils` is part of the global workspace, it is built into the `near-sffl/target/debug` directory. 
How to run test:
```shell
cd contracts/evm
forge test --ffi
```