### PR TITLE
Update `cargo-deny` versions

### DIFF
--- a/.github/workflows/deny-checks.yml
+++ b/.github/workflows/deny-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
+      - uses: taiki-e/install-action@2.34.1
         with:
-          tool: cargo-deny
+          tool: cargo-deny@0.14.24
       - run: cargo deny --all-features --locked check bans

--- a/.github/workflows/deny-checks.yml
+++ b/.github/workflows/deny-checks.yml
@@ -1,6 +1,7 @@
 name: License check
 
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/deny-checks.yml
+++ b/.github/workflows/deny-checks.yml
@@ -1,7 +1,6 @@
 name: License check
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/deny-checks.yml
+++ b/.github/workflows/deny-checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@2.34.1
+      - uses: taiki-e/install-action@v2.34.1
         with:
           tool: cargo-deny@0.14.24
       - run: cargo deny --all-features --locked check bans


### PR DESCRIPTION
Closes #205 by updating and pinning the `cargo-deny` and `taiki-e/install-action` tools