### PR TITLE
Fix flaky `SafeEthClient` tests

### DIFF
--- a/core/safeclient/client_test.go
+++ b/core/safeclient/client_test.go
@@ -622,8 +622,7 @@ func TestLogCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger, err := logging.NewZapLogger("development")
-	assert.NoError(t, err)
+	logger := logging.NewNoopLogger()
 
 	blockNum := uint64(0)
 	headerProxyC := make(chan *types.Header)


### PR DESCRIPTION
Fixes #207 by adding locks when needed and proper channel flushing. Issues were detected by using the `-race` flag. Only test code was changed.