### PR TITLE
Limit max DB connections to 1

### DIFF
--- a/aggregator/database/database.go
+++ b/aggregator/database/database.go
@@ -68,6 +68,13 @@ func NewDatabase(dbPath string) (*Database, error) {
 		&models.OperatorSetUpdateMessage{},
 	)
 
+	underlyingDb, err := db.DB()
+	if err != nil {
+		return nil, err
+	}
+
+	underlyingDb.SetMaxOpenConns(1)
+
 	return &Database{
 		db:       db,
 		dbPath:   dbPath,


### PR DESCRIPTION
We were having an issue on DB management: whenever the operators were making a checkpoint, they were calling `GetAggregatedCheckpointMessages`, which triggered a `SELECT` on the DB. Since we are continuously writing to the DB as well, if a write happened to be happening at the same time, the DB would be locked, as it's SQLite - not supposed to be concurrent.
An immediate fix to this is simply limiting the connections, as effectively we are not using more than one at once. 