### PR TITLE
Server parameter validation

### DIFF
--- a/aggregator/database/database.go
+++ b/aggregator/database/database.go
@@ -263,6 +263,10 @@ func (d *Database) FetchCheckpointMessages(fromTimestamp uint64, toTimestamp uin
 		return nil, errors.New("timestamp does not fit in int64")
 	}
 
+	if (toTimestamp < fromTimestamp) {
+		return nil, errors.New("toTimestamp is less than fromTimestamp")
+	}
+
 	start := time.Now()
 	defer func() { d.listener.OnFetch(time.Since(start)) }()
 

--- a/aggregator/database/database_test.go
+++ b/aggregator/database/database_test.go
@@ -313,3 +313,21 @@ func TestFetchCheckpointMessages(t *testing.T) {
 		OperatorSetUpdateMessageAggregations: []messages.MessageBlsAggregation{},
 	})
 }
+
+func TestFetchCheckpointMessages_TimestampTooLarge(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	db, err := database.NewDatabase(":memory:")
+	assert.Nil(t, err)
+
+	t.Run("fromTimestamp too large", func(t *testing.T) {
+		_, err := db.FetchCheckpointMessages(uint64(0x8000000000000000), 0)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("toTimestamp too large", func(t *testing.T) {
+		_, err := db.FetchCheckpointMessages(0, uint64(0x8000000000000000))
+		assert.NotNil(t, err)
+	})
+}

--- a/aggregator/database/database_test.go
+++ b/aggregator/database/database_test.go
@@ -331,3 +331,14 @@ func TestFetchCheckpointMessages_TimestampTooLarge(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 }
+
+func TestFetchCheckpointMessages_InvalidRange(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	db, err := database.NewDatabase(":memory:")
+	assert.Nil(t, err)
+
+	_, err = db.FetchCheckpointMessages(101, 100)
+	assert.NotNil(t, err)
+}

--- a/aggregator/rest_server.go
+++ b/aggregator/rest_server.go
@@ -69,12 +69,12 @@ func (agg *Aggregator) handleGetStateRootUpdateAggregation(w http.ResponseWriter
 
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(aggtypes.GetStateRootUpdateAggregationResponse{
+	err = json.NewEncoder(w).Encode(aggtypes.GetStateRootUpdateAggregationResponse{
 		Message:     *message,
 		Aggregation: *aggregation,
 	})
 
-	return nil
+	return err
 }
 
 func (agg *Aggregator) handleGetOperatorSetUpdateAggregation(w http.ResponseWriter, r *http.Request) error {
@@ -101,12 +101,12 @@ func (agg *Aggregator) handleGetOperatorSetUpdateAggregation(w http.ResponseWrit
 
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(aggtypes.GetOperatorSetUpdateAggregationResponse{
+	err = json.NewEncoder(w).Encode(aggtypes.GetOperatorSetUpdateAggregationResponse{
 		Message:     *message,
 		Aggregation: *aggregation,
 	})
 
-	return nil
+	return err
 }
 
 func (agg *Aggregator) handleGetCheckpointMessages(w http.ResponseWriter, r *http.Request) error {
@@ -133,9 +133,9 @@ func (agg *Aggregator) handleGetCheckpointMessages(w http.ResponseWriter, r *htt
 
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(aggtypes.GetCheckpointMessagesResponse{
+	err = json.NewEncoder(w).Encode(aggtypes.GetCheckpointMessagesResponse{
 		CheckpointMessages: *checkpointMessages,
 	})
 
-	return nil
+	return err
 }

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -198,7 +198,7 @@ func TestGetCheckpointMessages(t *testing.T) {
 	assert.Equal(t, body, expectedBody)
 }
 
-func TestStateRootUpdate_MissingParameters(t *testing.T) {
+func TestGetStateRootUpdateAggregation_MissingParameters(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -238,7 +238,7 @@ func TestStateRootUpdate_MissingParameters(t *testing.T) {
 	})
 }
 
-func TestStateRootUpdate_InvalidParameters(t *testing.T) {
+func TestGetStateRootUpdateAggregation_InvalidParameters(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -261,7 +261,7 @@ func TestStateRootUpdate_InvalidParameters(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 }
 
-func TestStateRootUpdate_EmptyParameters(t *testing.T) {
+func TestGetStateRootUpdateAggregation_EmptyParameters(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -20,7 +20,7 @@ func TestGetStateRootUpdateAggregation(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, mockDb, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -33,7 +33,7 @@ func TestGetStateRootUpdateAggregation(t *testing.T) {
 		StateRoot:           keccak256(6),
 	}
 	msgDigest, err := msg.Digest()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	aggregation := aggtypes.MessageBlsAggregationServiceResponse{
 		MessageBlsAggregation: messages.MessageBlsAggregation{
@@ -50,11 +50,12 @@ func TestGetStateRootUpdateAggregation(t *testing.T) {
 		fmt.Sprintf("/aggregation/state-root-update?rollupId=%d&blockHeight=%d", msg.RollupId, msg.BlockHeight),
 		nil,
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 
-	aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+	err = aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+	assert.NoError(t, err)
 
 	expectedBody := aggtypes.GetStateRootUpdateAggregationResponse{
 		Message:     msg,
@@ -69,7 +70,7 @@ func TestGetStateRootUpdateAggregation(t *testing.T) {
 	}
 
 	err = json.Unmarshal(recorder.Body.Bytes(), &body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, expectedBody, body)
 }
@@ -79,7 +80,7 @@ func TestGetOperatorSetUpdateAggregation(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, mockDb, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -88,7 +89,7 @@ func TestGetOperatorSetUpdateAggregation(t *testing.T) {
 		Timestamp: 2,
 	}
 	msgDigest, err := msg.Digest()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	aggregation := messages.MessageBlsAggregation{
 		MessageDigest: msgDigest,
@@ -103,7 +104,7 @@ func TestGetOperatorSetUpdateAggregation(t *testing.T) {
 		fmt.Sprintf("/aggregation/operator-set-update?id=%d", msg.Id),
 		nil,
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 
@@ -122,7 +123,7 @@ func TestGetOperatorSetUpdateAggregation(t *testing.T) {
 	}
 
 	err = json.Unmarshal(recorder.Body.Bytes(), &body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, expectedBody, body)
 }
@@ -132,7 +133,7 @@ func TestGetCheckpointMessages(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, mockDb, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -142,7 +143,7 @@ func TestGetCheckpointMessages(t *testing.T) {
 		Timestamp:   3,
 	}
 	msgDigest, err := msg.Digest()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	aggregation := messages.MessageBlsAggregation{
 		MessageDigest: msgDigest,
@@ -153,7 +154,7 @@ func TestGetCheckpointMessages(t *testing.T) {
 		Timestamp: 2,
 	}
 	msgDigest2, err := msg2.Digest()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	aggregation2 := messages.MessageBlsAggregation{
 		MessageDigest: msgDigest2,
@@ -171,11 +172,12 @@ func TestGetCheckpointMessages(t *testing.T) {
 		fmt.Sprintf("/checkpoint/messages?fromTimestamp=%d&toTimestamp=%d", 0, 3),
 		nil,
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 
-	aggregator.handleGetCheckpointMessages(recorder, req)
+	err = aggregator.handleGetCheckpointMessages(recorder, req)
+	assert.NoError(t, err)
 
 	expectedBody := aggtypes.GetCheckpointMessagesResponse{
 		CheckpointMessages: messages.CheckpointMessages{
@@ -194,7 +196,7 @@ func TestGetCheckpointMessages(t *testing.T) {
 	}
 
 	err = json.Unmarshal(recorder.Body.Bytes(), &body)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, expectedBody, body)
 }
@@ -204,7 +206,7 @@ func TestGetStateRootUpdateAggregation_MissingParameters(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, _, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -214,7 +216,7 @@ func TestGetStateRootUpdateAggregation_MissingParameters(t *testing.T) {
 			fmt.Sprintf("/aggregation/state-root-update?blockHeight=%d", 0),
 			nil,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		recorder := httptest.NewRecorder()
 
@@ -230,7 +232,7 @@ func TestGetStateRootUpdateAggregation_MissingParameters(t *testing.T) {
 			fmt.Sprintf("/aggregation/state-root-update?&rollupId=%d", 0),
 			nil,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		recorder := httptest.NewRecorder()
 
@@ -246,7 +248,7 @@ func TestGetStateRootUpdateAggregation_InvalidParameters(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, _, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -256,7 +258,7 @@ func TestGetStateRootUpdateAggregation_InvalidParameters(t *testing.T) {
 			fmt.Sprintf("/aggregation/state-root-update?rollupId=%s&blockHeight=%d", "foo", 0),
 			nil,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		recorder := httptest.NewRecorder()
 
@@ -272,7 +274,7 @@ func TestGetStateRootUpdateAggregation_InvalidParameters(t *testing.T) {
 			fmt.Sprintf("/aggregation/state-root-update?rollupId=%d&blockHeight=%d", uint64(0xFFFFFFFFFFFFFFFF), 0),
 			nil,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		recorder := httptest.NewRecorder()
 
@@ -288,7 +290,7 @@ func TestGetStateRootUpdateAggregation_InvalidParameters(t *testing.T) {
 			fmt.Sprintf("/aggregation/state-root-update?rollupId=%d&blockHeight=%s", 0, "foo"),
 			nil,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		recorder := httptest.NewRecorder()
 
@@ -304,7 +306,7 @@ func TestGetStateRootUpdateAggregation_EmptyParameters(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, _, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -313,7 +315,7 @@ func TestGetStateRootUpdateAggregation_EmptyParameters(t *testing.T) {
 		"/aggregation/state-root-update?rollupId=&blockHeight=",
 		nil,
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 
@@ -328,7 +330,7 @@ func TestGetStateRootUpdateAggregation_StateRootUpdateNotFound(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, mockDb, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -340,7 +342,7 @@ func TestGetStateRootUpdateAggregation_StateRootUpdateNotFound(t *testing.T) {
 		fmt.Sprintf("/aggregation/state-root-update?rollupId=%d&blockHeight=%d", 0, 0),
 		nil,
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 
@@ -355,7 +357,7 @@ func TestGetStateRootUpdateAggregation_StateRootUpdateAggregationNotFound(t *tes
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, mockDb, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -368,7 +370,7 @@ func TestGetStateRootUpdateAggregation_StateRootUpdateAggregationNotFound(t *tes
 		fmt.Sprintf("/aggregation/state-root-update?rollupId=%d&blockHeight=%d", 0, 0),
 		nil,
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 
@@ -383,7 +385,7 @@ func TestGetOperatorSetUpdateAggregation_MissingParameter(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, _, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -393,7 +395,7 @@ func TestGetOperatorSetUpdateAggregation_MissingParameter(t *testing.T) {
 			"/aggregation/operator-set-update",
 			nil,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		recorder := httptest.NewRecorder()
 
@@ -409,7 +411,7 @@ func TestGetOperatorSetUpdateAggregation_OperatorSetUpdateNotFound(t *testing.T)
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, mockDb, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -421,7 +423,7 @@ func TestGetOperatorSetUpdateAggregation_OperatorSetUpdateNotFound(t *testing.T)
 		fmt.Sprintf("/aggregation/operator-set-update?id=%d", 0),
 		nil,
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 
@@ -436,7 +438,7 @@ func TestGetOperatorSetUpdateAggregation_OperatorSetUpdateAggregationNotFound(t 
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, mockDb, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -449,7 +451,7 @@ func TestGetOperatorSetUpdateAggregation_OperatorSetUpdateAggregationNotFound(t 
 		fmt.Sprintf("/aggregation/operator-set-update?id=%d", 0),
 		nil,
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 
@@ -464,7 +466,7 @@ func TestGetCheckpointMessages_MissingParameters(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, _, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -474,7 +476,7 @@ func TestGetCheckpointMessages_MissingParameters(t *testing.T) {
 			fmt.Sprintf("/checkpoint/messages?toTimestamp=%d", 0),
 			nil,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		recorder := httptest.NewRecorder()
 
@@ -490,7 +492,7 @@ func TestGetCheckpointMessages_MissingParameters(t *testing.T) {
 			fmt.Sprintf("/checkpoint/messages?fromTimestamp=%d", 0),
 			nil,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		recorder := httptest.NewRecorder()
 
@@ -506,7 +508,7 @@ func TestGetCheckpointMessages_InvalidParameters(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, _, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -516,7 +518,7 @@ func TestGetCheckpointMessages_InvalidParameters(t *testing.T) {
 			fmt.Sprintf("/checkpoint/messages?fromTimestamp=%s&toTimestamp=%d", "foo", 0),
 			nil,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		recorder := httptest.NewRecorder()
 
@@ -532,7 +534,7 @@ func TestGetCheckpointMessages_InvalidParameters(t *testing.T) {
 			fmt.Sprintf("/checkpoint/messages?fromTimestamp=%d&toTimestamp=%s", 0, "foo"),
 			nil,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		recorder := httptest.NewRecorder()
 
@@ -548,7 +550,7 @@ func TestGetCheckpointMessages_CheckpointMessageNotFound(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	aggregator, _, _, _, _, _, mockDb, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go aggregator.startRestServer()
 
@@ -560,7 +562,7 @@ func TestGetCheckpointMessages_CheckpointMessageNotFound(t *testing.T) {
 		fmt.Sprintf("/checkpoint/messages?fromTimestamp=%d&toTimestamp=%d", 100, 200),
 		nil,
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
 

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -369,3 +369,28 @@ func TestGetStateRootUpdateAggregation_StateRootUpdateAggregationNotFound(t *tes
 
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 }
+
+func TestGetOperatorSetUpdateAggregation_MissingParameter(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	aggregator, _, _, _, _, _, _, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
+	assert.Nil(t, err)
+
+	go aggregator.startRestServer()
+
+	t.Run("Missing id", func(t *testing.T) {
+		req, err := http.NewRequest(
+			"GET",
+			"/aggregation/operator-set-update",
+			nil,
+		)
+		assert.Nil(t, err)
+
+		recorder := httptest.NewRecorder()
+
+		aggregator.handleGetOperatorSetUpdateAggregation(recorder, req)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+}

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -211,7 +211,7 @@ func TestGetStateRootUpdateAggregation_MissingParameters(t *testing.T) {
 	t.Run("Missing rollupId", func(t *testing.T) {
 		req, err := http.NewRequest(
 			"GET",
-			fmt.Sprintf("/aggregation/state-root-update?&blockHeight=%d", 0),
+			fmt.Sprintf("/aggregation/state-root-update?blockHeight=%d", 0),
 			nil,
 		)
 		assert.Nil(t, err)

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -394,3 +394,56 @@ func TestGetOperatorSetUpdateAggregation_MissingParameter(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
 }
+
+func TestGetOperatorSetUpdateAggregation_OperatorSetUpdateNotFound(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	aggregator, _, _, _, _, _, mockDb, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
+	assert.Nil(t, err)
+
+	go aggregator.startRestServer()
+
+	notFound := errors.New("not found")
+	mockDb.EXPECT().FetchOperatorSetUpdate(gomock.Any()).Return(nil, notFound)
+
+	req, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf("/aggregation/operator-set-update?id=%d", 0),
+		nil,
+	)
+	assert.Nil(t, err)
+
+	recorder := httptest.NewRecorder()
+
+	aggregator.handleGetOperatorSetUpdateAggregation(recorder, req)
+
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+}
+
+func TestGetOperatorSetUpdateAggregation_OperatorSetUpdateAggregationNotFound(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	aggregator, _, _, _, _, _, mockDb, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
+	assert.Nil(t, err)
+
+	go aggregator.startRestServer()
+
+	notFound := errors.New("not found")
+	mockDb.EXPECT().FetchOperatorSetUpdate(gomock.Any()).Return(&messages.OperatorSetUpdateMessage{}, nil)
+	mockDb.EXPECT().FetchOperatorSetUpdateAggregation(gomock.Any()).Return(nil, notFound)
+
+	req, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf("/aggregation/operator-set-update?id=%d", 0),
+		nil,
+	)
+	assert.Nil(t, err)
+
+	recorder := httptest.NewRecorder()
+
+	aggregator.handleGetOperatorSetUpdateAggregation(recorder, req)
+
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+}

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -218,7 +218,8 @@ func TestGetStateRootUpdateAggregation_MissingParameters(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 
-		aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		err = aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		assert.NotNil(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
@@ -233,7 +234,8 @@ func TestGetStateRootUpdateAggregation_MissingParameters(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 
-		aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		err = aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		assert.NotNil(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
@@ -258,7 +260,8 @@ func TestGetStateRootUpdateAggregation_InvalidParameters(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 
-		aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		err = aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		assert.NotNil(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
@@ -273,7 +276,8 @@ func TestGetStateRootUpdateAggregation_InvalidParameters(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 
-		aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		err = aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		assert.NotNil(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
@@ -288,7 +292,8 @@ func TestGetStateRootUpdateAggregation_InvalidParameters(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 
-		aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		err = aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		assert.NotNil(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
@@ -312,7 +317,8 @@ func TestGetStateRootUpdateAggregation_EmptyParameters(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+	err = aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+	assert.NotNil(t, err)
 
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 }
@@ -338,7 +344,8 @@ func TestGetStateRootUpdateAggregation_StateRootUpdateNotFound(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+	err = aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+	assert.NotNil(t, err)
 
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 }
@@ -365,7 +372,8 @@ func TestGetStateRootUpdateAggregation_StateRootUpdateAggregationNotFound(t *tes
 
 	recorder := httptest.NewRecorder()
 
-	aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+	err = aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+	assert.NotNil(t, err)
 
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 }
@@ -389,7 +397,8 @@ func TestGetOperatorSetUpdateAggregation_MissingParameter(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 
-		aggregator.handleGetOperatorSetUpdateAggregation(recorder, req)
+		err = aggregator.handleGetOperatorSetUpdateAggregation(recorder, req)
+		assert.NotNil(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
@@ -416,7 +425,8 @@ func TestGetOperatorSetUpdateAggregation_OperatorSetUpdateNotFound(t *testing.T)
 
 	recorder := httptest.NewRecorder()
 
-	aggregator.handleGetOperatorSetUpdateAggregation(recorder, req)
+	err = aggregator.handleGetOperatorSetUpdateAggregation(recorder, req)
+	assert.NotNil(t, err)
 
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 }
@@ -443,7 +453,8 @@ func TestGetOperatorSetUpdateAggregation_OperatorSetUpdateAggregationNotFound(t 
 
 	recorder := httptest.NewRecorder()
 
-	aggregator.handleGetOperatorSetUpdateAggregation(recorder, req)
+	err = aggregator.handleGetOperatorSetUpdateAggregation(recorder, req)
+	assert.NotNil(t, err)
 
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 }
@@ -467,7 +478,8 @@ func TestGetCheckpointMessages_MissingParameters(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 
-		aggregator.handleGetCheckpointMessages(recorder, req)
+		err = aggregator.handleGetCheckpointMessages(recorder, req)
+		assert.NotNil(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
@@ -482,7 +494,8 @@ func TestGetCheckpointMessages_MissingParameters(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 
-		aggregator.handleGetCheckpointMessages(recorder, req)
+		err = aggregator.handleGetCheckpointMessages(recorder, req)
+		assert.NotNil(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
@@ -507,7 +520,8 @@ func TestGetCheckpointMessages_InvalidParameters(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 
-		aggregator.handleGetCheckpointMessages(recorder, req)
+		err = aggregator.handleGetCheckpointMessages(recorder, req)
+		assert.NotNil(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
@@ -522,7 +536,8 @@ func TestGetCheckpointMessages_InvalidParameters(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 
-		aggregator.handleGetCheckpointMessages(recorder, req)
+		err = aggregator.handleGetCheckpointMessages(recorder, req)
+		assert.NotNil(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
@@ -549,7 +564,8 @@ func TestGetCheckpointMessages_CheckpointMessageNotFound(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 
-	aggregator.handleGetCheckpointMessages(recorder, req)
+	err = aggregator.handleGetCheckpointMessages(recorder, req)
+	assert.NotNil(t, err)
 
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 }

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -197,3 +197,43 @@ func TestGetCheckpointMessages(t *testing.T) {
 
 	assert.Equal(t, body, expectedBody)
 }
+
+func TestStateRootUpdate_MissingParameters(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	aggregator, _, _, _, _, _, _, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
+	assert.Nil(t, err)
+
+	go aggregator.startRestServer()
+
+	t.Run("Missing rollupId", func(t *testing.T) {
+		req, err := http.NewRequest(
+			"GET",
+			fmt.Sprintf("/aggregation/state-root-update?&blockHeight=%d", 0),
+			nil,
+		)
+		assert.Nil(t, err)
+
+		recorder := httptest.NewRecorder()
+
+		aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("Missing blockHeight", func(t *testing.T) {
+		req, err := http.NewRequest(
+			"GET",
+			fmt.Sprintf("/aggregation/state-root-update?&rollupId=%d", 0),
+			nil,
+		)
+		assert.Nil(t, err)
+
+		recorder := httptest.NewRecorder()
+
+		aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+}

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -237,3 +237,26 @@ func TestStateRootUpdate_MissingParameters(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
 }
+
+func TestStateRootUpdate_InvalidParameters(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	aggregator, _, _, _, _, _, _, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
+	assert.Nil(t, err)
+
+	go aggregator.startRestServer()
+
+	req, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf("/aggregation/state-root-update?rollupId=%s&blockHeight=%s", "foo", "bar"),
+		nil,
+	)
+	assert.Nil(t, err)
+
+	recorder := httptest.NewRecorder()
+
+	aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+}

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -61,7 +61,7 @@ func TestGetStateRootUpdateAggregation(t *testing.T) {
 	}
 	var body aggtypes.GetStateRootUpdateAggregationResponse
 
-	assert.Equal(t, recorder.Code, http.StatusOK)
+	assert.Equal(t, http.StatusOK, recorder.Code)
 
 	if recorder.Code != http.StatusOK {
 		fmt.Printf("HTTP Error: %s", recorder.Body.Bytes())
@@ -70,7 +70,7 @@ func TestGetStateRootUpdateAggregation(t *testing.T) {
 	err = json.Unmarshal(recorder.Body.Bytes(), &body)
 	assert.Nil(t, err)
 
-	assert.Equal(t, body, expectedBody)
+	assert.Equal(t, expectedBody, body)
 }
 
 func TestGetOperatorSetUpdateAggregation(t *testing.T) {
@@ -114,7 +114,7 @@ func TestGetOperatorSetUpdateAggregation(t *testing.T) {
 	}
 	var body aggtypes.GetOperatorSetUpdateAggregationResponse
 
-	assert.Equal(t, recorder.Code, http.StatusOK)
+	assert.Equal(t, http.StatusOK, recorder.Code)
 
 	if recorder.Code != http.StatusOK {
 		fmt.Printf("HTTP Error: %s", recorder.Body.Bytes())
@@ -123,7 +123,7 @@ func TestGetOperatorSetUpdateAggregation(t *testing.T) {
 	err = json.Unmarshal(recorder.Body.Bytes(), &body)
 	assert.Nil(t, err)
 
-	assert.Equal(t, body, expectedBody)
+	assert.Equal(t, expectedBody, body)
 }
 
 func TestGetCheckpointMessages(t *testing.T) {
@@ -186,7 +186,7 @@ func TestGetCheckpointMessages(t *testing.T) {
 	}
 	var body aggtypes.GetCheckpointMessagesResponse
 
-	assert.Equal(t, recorder.Code, http.StatusOK)
+	assert.Equal(t, http.StatusOK, recorder.Code)
 
 	if recorder.Code != http.StatusOK {
 		fmt.Printf("HTTP Error: %s", recorder.Body.Bytes())
@@ -195,7 +195,7 @@ func TestGetCheckpointMessages(t *testing.T) {
 	err = json.Unmarshal(recorder.Body.Bytes(), &body)
 	assert.Nil(t, err)
 
-	assert.Equal(t, body, expectedBody)
+	assert.Equal(t, expectedBody, body)
 }
 
 func TestGetStateRootUpdateAggregation_MissingParameters(t *testing.T) {

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -2,7 +2,6 @@ package aggregator
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -334,8 +333,7 @@ func TestGetStateRootUpdateAggregation_StateRootUpdateNotFound(t *testing.T) {
 
 	go aggregator.startRestServer()
 
-	notFound := errors.New("not found")
-	mockDb.EXPECT().FetchStateRootUpdate(gomock.Any(), gomock.Any()).Return(nil, notFound)
+	mockDb.EXPECT().FetchStateRootUpdate(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 
 	req, err := http.NewRequest(
 		"GET",
@@ -361,9 +359,8 @@ func TestGetStateRootUpdateAggregation_StateRootUpdateAggregationNotFound(t *tes
 
 	go aggregator.startRestServer()
 
-	notFound := errors.New("not found")
 	mockDb.EXPECT().FetchStateRootUpdate(gomock.Any(), gomock.Any()).Return(&messages.StateRootUpdateMessage{}, nil)
-	mockDb.EXPECT().FetchStateRootUpdateAggregation(gomock.Any(), gomock.Any()).Return(nil, notFound)
+	mockDb.EXPECT().FetchStateRootUpdateAggregation(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 
 	req, err := http.NewRequest(
 		"GET",
@@ -415,8 +412,7 @@ func TestGetOperatorSetUpdateAggregation_OperatorSetUpdateNotFound(t *testing.T)
 
 	go aggregator.startRestServer()
 
-	notFound := errors.New("not found")
-	mockDb.EXPECT().FetchOperatorSetUpdate(gomock.Any()).Return(nil, notFound)
+	mockDb.EXPECT().FetchOperatorSetUpdate(gomock.Any()).Return(nil, assert.AnError)
 
 	req, err := http.NewRequest(
 		"GET",
@@ -442,9 +438,8 @@ func TestGetOperatorSetUpdateAggregation_OperatorSetUpdateAggregationNotFound(t 
 
 	go aggregator.startRestServer()
 
-	notFound := errors.New("not found")
 	mockDb.EXPECT().FetchOperatorSetUpdate(gomock.Any()).Return(&messages.OperatorSetUpdateMessage{}, nil)
-	mockDb.EXPECT().FetchOperatorSetUpdateAggregation(gomock.Any()).Return(nil, notFound)
+	mockDb.EXPECT().FetchOperatorSetUpdateAggregation(gomock.Any()).Return(nil, assert.AnError)
 
 	req, err := http.NewRequest(
 		"GET",
@@ -554,8 +549,7 @@ func TestGetCheckpointMessages_CheckpointMessageNotFound(t *testing.T) {
 
 	go aggregator.startRestServer()
 
-	notFound := errors.New("not found")
-	mockDb.EXPECT().FetchCheckpointMessages(gomock.Any(), gomock.Any()).Return(nil, notFound)
+	mockDb.EXPECT().FetchCheckpointMessages(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 
 	req, err := http.NewRequest(
 		"GET",

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -247,18 +247,50 @@ func TestGetStateRootUpdateAggregation_InvalidParameters(t *testing.T) {
 
 	go aggregator.startRestServer()
 
-	req, err := http.NewRequest(
-		"GET",
-		fmt.Sprintf("/aggregation/state-root-update?rollupId=%s&blockHeight=%s", "foo", "bar"),
-		nil,
-	)
-	assert.Nil(t, err)
+	t.Run("Invalid rollupId - incorrect type", func(t *testing.T) {
+		req, err := http.NewRequest(
+			"GET",
+			fmt.Sprintf("/aggregation/state-root-update?rollupId=%s&blockHeight=%d", "foo", 0),
+			nil,
+		)
+		assert.Nil(t, err)
 
-	recorder := httptest.NewRecorder()
+		recorder := httptest.NewRecorder()
 
-	aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+		aggregator.handleGetStateRootUpdateAggregation(recorder, req)
 
-	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("Invalid rollupId - too large", func(t *testing.T) {
+		req, err := http.NewRequest(
+			"GET",
+			fmt.Sprintf("/aggregation/state-root-update?rollupId=%d&blockHeight=%d", uint64(0xFFFFFFFFFFFFFFFF), 0),
+			nil,
+		)
+		assert.Nil(t, err)
+
+		recorder := httptest.NewRecorder()
+
+		aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("Invalid blockHeight - incorrect type", func(t *testing.T) {
+		req, err := http.NewRequest(
+			"GET",
+			fmt.Sprintf("/aggregation/state-root-update?rollupId=%d&blockHeight=%s", 0, "foo"),
+			nil,
+		)
+		assert.Nil(t, err)
+
+		recorder := httptest.NewRecorder()
+
+		aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
 }
 
 func TestGetStateRootUpdateAggregation_EmptyParameters(t *testing.T) {

--- a/aggregator/rest_server_test.go
+++ b/aggregator/rest_server_test.go
@@ -260,3 +260,26 @@ func TestStateRootUpdate_InvalidParameters(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 }
+
+func TestStateRootUpdate_EmptyParameters(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	aggregator, _, _, _, _, _, _, _, _, err := createMockAggregator(mockCtrl, MOCK_OPERATOR_PUBKEY_DICT)
+	assert.Nil(t, err)
+
+	go aggregator.startRestServer()
+
+	req, err := http.NewRequest(
+		"GET",
+		"/aggregation/state-root-update?rollupId=&blockHeight=",
+		nil,
+	)
+	assert.Nil(t, err)
+
+	recorder := httptest.NewRecorder()
+
+	aggregator.handleGetStateRootUpdateAggregation(recorder, req)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+}


### PR DESCRIPTION
## Current Behavior

Partially solves https://github.com/NethermindEth/near-sffl/issues/239 by introducing additional bounds checks to the checkpoint messages fetching. It also adds additional tests for parameter deserializing.

## New Behavior

Ensures that ranges `from - to` are valid, that is `from < to` is always satisfied.

## Breaking Changes

Certain queries that would previously return an empty result set now return an error message indicating that the range provided is invalid.

## Observations

There is quite a complicated issue with the storage of `BlockNumber` and `Timestamp` as defined here:

https://github.com/NethermindEth/near-sffl/blob/18544a6716cb6fe0cb91f928ba1f476cc7bcaa5f/core/types/fields.go#L14-L15

> I'm assuming that this timestamp is representing a Unix timestamp

These types are used in `StateRootUpdateMessage`

https://github.com/NethermindEth/near-sffl/blob/18544a6716cb6fe0cb91f928ba1f476cc7bcaa5f/core/types/messages/state_root_update.go#L18-L19

This message type then gets converted to a specific model when interacting with the DB:

https://github.com/NethermindEth/near-sffl/blob/18544a6716cb6fe0cb91f928ba1f476cc7bcaa5f/aggregator/database/models/state_root_update.go#L12-L13

As noted, there is a pending range check to perform. SQLite by default does not support `uint64` values (and neither other DBs like Postgres), allowing only `int64` values. For both fields, if we try to store `math.MaxUint64` we'll get the following SQL error:

```
uint64 values with high bit set are not supported
```

I'm not 100% sure who is to blame here (gorm, SQLite), but this means that in the future, if we have either a `BlockHeight` or a `Timestamp` greater than `math.MaxInt64` then we'll get an error.

Possible actions:
1. Do nothing since we can guess that such high values will not show up in the near future.
2. Add a check to prevent inserting these values in the DB. This is not that different from 1 but at least we control what to do on errors
3. Change the DB schema to store these values, ex. store them as `text`. Curiously we get the same error on `BlockHeight` despite technically using `text` as a type which makes things a bit confusing. Either way, changing the schema would mean a breaking change which we want to avoid at least for the time being.