### PR TITLE
Add Golang linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,2 @@
+run:
+  tests: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,2 +1,3 @@
 run:
+  # TODO: We want to eventually enable linting for all files, including test code
   tests: false

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ INDEXER_NEAR_CLI_LOCALNET_KEY_PATH=${HOME}/.near/localnet/validator_key.json
 CHAINID=31337
 DEPLOYMENT_FILES_DIR=contracts/evm/script/output/${CHAINID}
 
------------------------------: ## 
+-----------------------------: ##
 
-___CONTRACTS___: ## 
+___CONTRACTS___: ##
 
 deploy-eigenlayer-contracts-to-anvil-and-save-state: ## Deploy eigenlayer
 	./tests/anvil/deploy-eigenlayer-save-anvil-state.sh
@@ -26,7 +26,7 @@ deploy-eigenlayer-contracts-to-anvil-and-save-state: ## Deploy eigenlayer
 deploy-sffl-contracts-to-anvil-and-save-state: ## Deploy avs
 	./tests/anvil/deploy-avs-save-anvil-state.sh
 
-deploy-all-to-anvil-and-save-state: deploy-eigenlayer-contracts-to-anvil-and-save-state deploy-sffl-contracts-to-anvil-and-save-state ## deploy eigenlayer, shared avs contracts, and inc-sq contracts 
+deploy-all-to-anvil-and-save-state: deploy-eigenlayer-contracts-to-anvil-and-save-state deploy-sffl-contracts-to-anvil-and-save-state ## deploy eigenlayer, shared avs contracts, and inc-sq contracts
 
 start-anvil-chain-with-el-and-avs-deployed: ## starts anvil from a saved state file (with el and avs contracts deployed)
 	./tests/anvil/start-anvil-chain-with-el-and-avs-deployed.sh
@@ -59,7 +59,7 @@ docker-build-images: docker-build-indexer docker-build-relayer docker-build-aggr
 docker-start-everything: docker-build-images ## starts aggregator and operator docker containers
 	docker compose up
 
-__CLI__: ## 
+__CLI__: ##
 
 cli-setup-operator: export OPERATOR_BLS_KEY_PASSWORD=$(OPERATOR_BLS_KEY_PASS)
 cli-setup-operator: export OPERATOR_ECDSA_KEY_PASSWORD=$(OPERATOR_ECDSA_KEY_PASS)
@@ -68,26 +68,26 @@ cli-setup-operator: send-fund cli-register-operator-with-eigenlayer cli-deposit-
 cli-register-operator-with-eigenlayer: ## registers operator with delegationManager
 	go run cli/main.go --config config-files/operator.anvil.yaml register-operator-with-eigenlayer
 
-cli-deposit-into-mocktoken-strategy: ## 
+cli-deposit-into-mocktoken-strategy: ##
 	./scripts/deposit-into-mocktoken-strategy.sh
 
-cli-register-operator-with-avs: ## 
+cli-register-operator-with-avs: ##
 	go run cli/main.go --config config-files/operator.anvil.yaml register-operator-with-avs
 
-cli-deregister-operator-with-avs: ## 
+cli-deregister-operator-with-avs: ##
 	go run cli/main.go --config config-files/operator.anvil.yaml deregister-operator-with-avs
 
-cli-print-operator-status: ## 
+cli-print-operator-status: ##
 	go run cli/main.go --config config-files/operator.anvil.yaml print-operator-status
 
 send-fund: ## sends fund to the first operator saved in tests/keys/ecdsa/*
 	cast send 0xD5A0359da7B310917d7760385516B2426E86ab7f --value 10ether --private-key 0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6 --rpc-url http://127.0.0.1:8545
 
------------------------------: ## 
+-----------------------------: ##
 # We pipe all zapper logs through https://github.com/maoueh/zap-pretty so make sure to install it
 # TODO: piping to zap-pretty only works when zapper environment is set to production, unsure why
-____OFFCHAIN_SOFTWARE___: ## 
-start-aggregator: ## 
+____OFFCHAIN_SOFTWARE___: ##
+start-aggregator: ##
 	go run aggregator/cmd/main.go --config config-files/aggregator.yaml \
 		--sffl-deployment ${DEPLOYMENT_FILES_DIR}/sffl_avs_deployment_output.json \
 		--ecdsa-private-key ${AGGREGATOR_ECDSA_PRIV_KEY} \
@@ -95,21 +95,21 @@ start-aggregator: ##
 
 start-operator: export OPERATOR_BLS_KEY_PASSWORD=fDUMDLmBROwlzzPXyIcy
 start-operator: export OPERATOR_ECDSA_KEY_PASSWORD=EnJuncq01CiVk9UbuBYl
-start-operator: ## 
+start-operator: ##
 	go run operator/cmd/main.go --config config-files/operator.anvil.yaml \
 		2>&1 | zap-pretty
 
-start-indexer: ## 
+start-indexer: ##
 	cargo run -p indexer --release -- --home-dir ~/.near/localnet init --chain-id localnet
 	cargo run -p indexer --release -- --home-dir ~/.near/localnet run --da-contract-ids da.test.near --rollup-ids 2 --rmq-address "amqp://127.0.0.1:5672"
 
 start-test-relayer: ##
 	go run relayer/cmd/main.go --rpc-url ws://127.0.0.1:8546 --da-account-id da.test.near
 
-run-plugin: ## 
+run-plugin: ##
 	go run plugin/cmd/main.go --config config-files/operator.anvil.yaml
------------------------------: ## 
-_____HELPER_____: ## 
+-----------------------------: ##
+_____HELPER_____: ##
 mocks: ## generates mocks for tests
 	go install go.uber.org/mock/mockgen@v0.3.0
 	go generate ./...
@@ -125,3 +125,7 @@ tests-integration: ## runs all integration tests
 	go test ./tests/integration/integration_test.go -v -count=1
 	go test ./tests/integration/registration_test.go -v -count=1
 
+## runs linter on all files
+## TODO: For now, only Go files are linted
+lint:
+	golangci-lint run

--- a/aggregator/database/database.go
+++ b/aggregator/database/database.go
@@ -63,11 +63,14 @@ func NewDatabase(dbPath string) (*Database, error) {
 		return nil, err
 	}
 
-	db.AutoMigrate(
+	err = db.AutoMigrate(
 		&models.MessageBlsAggregation{},
 		&models.StateRootUpdateMessage{},
 		&models.OperatorSetUpdateMessage{},
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	underlyingDb, err := db.DB()
 	if err != nil {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -119,7 +119,11 @@ func NewConfig(ctx *cli.Context, configRaw ConfigRaw, logger sdklogging.Logger) 
 	if _, err := os.Stat(sfflDeploymentFilePath); errors.Is(err, os.ErrNotExist) {
 		panic("Path " + sfflDeploymentFilePath + " does not exist")
 	}
-	sdkutils.ReadJsonConfig(sfflDeploymentFilePath, &sfflDeploymentRaw)
+	err := sdkutils.ReadJsonConfig(sfflDeploymentFilePath, &sfflDeploymentRaw)
+	if err != nil {
+		logger.Error("Cannot read JSON config", "err", err)
+		return nil, err
+	}
 
 	ecdsaPrivateKeyString := ctx.GlobalString(EcdsaPrivateKeyFlag.Name)
 	if ecdsaPrivateKeyString[:2] == "0x" {

--- a/operator/avs_manager.go
+++ b/operator/avs_manager.go
@@ -205,6 +205,10 @@ func (avsManager *AvsManager) DepositIntoStrategy(operatorAddr common.Address, s
 		return err
 	}
 	txOpts, err := avsManager.avsWriter.TxMgr.GetNoSendTxOpts()
+	if err != nil {
+		avsManager.logger.Error("Error getting tx options")
+		return err
+	}
 	tx, err := contractErc20Mock.Mint(txOpts, operatorAddr, amount)
 	if err != nil {
 		avsManager.logger.Error("Error assembling Mint tx")

--- a/operator/rpc_client.go
+++ b/operator/rpc_client.go
@@ -153,12 +153,10 @@ func isShutdownOrNetworkError(err error) bool {
 	return false
 }
 
-func (c *AggregatorRpcClient) handleRpcError(err error) error {
+func (c *AggregatorRpcClient) handleRpcError(err error) {
 	if isShutdownOrNetworkError(err) {
 		go c.handleRpcShutdown()
 	}
-
-	return nil
 }
 
 func (c *AggregatorRpcClient) handleRpcShutdown() {

--- a/operator/rpc_client.go
+++ b/operator/rpc_client.go
@@ -289,9 +289,10 @@ func (c *AggregatorRpcClient) sendOperatorMessage(sendCb func() error, message i
 
 	appendProtected := func() {
 		c.unsentMessagesLock.Lock()
+		defer c.unsentMessagesLock.Unlock()
+
 		c.unsentMessages = append(c.unsentMessages, unsentRpcMessage{Message: message})
 		c.listener.ObserveResendQueueSize(len(c.unsentMessages))
-		c.unsentMessagesLock.Unlock()
 	}
 
 	if c.rpcClient == nil {

--- a/tests/integration/utils/containers.go
+++ b/tests/integration/utils/containers.go
@@ -236,7 +236,10 @@ func StartAnvilTestContainer(t *testing.T, ctx context.Context, name, exposedPor
 	}
 
 	if isMainnet {
-		anvil.Mine(big.NewInt(100), big.NewInt(1))
+		err := anvil.Mine(big.NewInt(100), big.NewInt(1))
+		if err != nil {
+			t.Fatalf("Anvil failed to Mine: %s", err.Error())
+		}
 	}
 
 	return anvil


### PR DESCRIPTION
## Current Behavior

Currently no static analysis tools are being used as part of our build process (either local or CI).

## New Behavior

As part of #215, we add [golangci-lint](https://golangci-lint.run) as an additional dependency to lint Go files. The linter can be run using `make lint`.

## Breaking Changes

This is not a breaking change since it adds a new Make target without affecting existing ones. Those who want to use the linter will need to add them to their dev enviroments

## Observations

This PR also includes some fixes based on the linting results, mostly involving proper error handling (some errors were being ignored).

In the near future we want to:
- Address all current linting issues (fix or ignore accordingly)
- Enable linting for tests files
- Enable linting in CI as an additional check
