### PR TITLE
Inject metrics registry as parameter

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -138,12 +138,13 @@ var _ RpcAggregatorer = (*Aggregator)(nil)
 var _ RestAggregatorer = (*Aggregator)(nil)
 
 // NewAggregator creates a new Aggregator with the provided config.
-// TODO: Remove this context once OperatorPubkeysServiceInMemory's API is
-// changed and we can gracefully exit otherwise
-func NewAggregator(ctx context.Context, config *config.Config, logger logging.Logger) (*Aggregator, error) {
-	// TODO: Pass the registry as a parameter (see https://github.com/NethermindEth/near-sffl/pull/211#pullrequestreview-2101946551)
-	registry := prometheus.NewRegistry()
-
+func NewAggregator(
+	// TODO: Remove `ctx` once OperatorsInfoServiceInMemory's API is changed and we can gracefully exit otherwise
+	ctx context.Context,
+	config *config.Config,
+	registry *prometheus.Registry,
+	logger logging.Logger,
+) (*Aggregator, error) {
 	ethHttpClient, err := core.CreateEthClientWithCollector(AggregatorNamespace, config.EthHttpRpcUrl, config.EnableMetrics, registry, logger)
 	if err != nil {
 		logger.Error("Cannot create http ethclient", "err", err)
@@ -613,11 +614,6 @@ func (agg *Aggregator) ProcessSignedOperatorSetUpdateMessage(signedOperatorSetUp
 	)
 
 	return err
-}
-
-// May return nil
-func (agg *Aggregator) GetRegistry() *prometheus.Registry {
-	return agg.registry
 }
 
 func (agg *Aggregator) GetAggregatedCheckpointMessages(fromTimestamp, toTimestamp uint64) (*messages.CheckpointMessages, error) {

--- a/aggregator/rpc_server/server.go
+++ b/aggregator/rpc_server/server.go
@@ -3,11 +3,12 @@ package rpc_server
 import (
 	"errors"
 	"fmt"
-	"github.com/NethermindEth/near-sffl/core"
-	"github.com/prometheus/client_golang/prometheus"
 	"net/http"
 	"net/rpc"
 	"strings"
+
+	"github.com/NethermindEth/near-sffl/core"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	eigentypes "github.com/Layr-Labs/eigensdk-go/types"


### PR DESCRIPTION
## Current Behavior

Currently, the Aggregator constructs a prometheus registry rather than accepting one as a parameter introducing some friction when trying to use the same registry in the RPC/REST servers.

## New Behavior

We lift the construction of the registry to `main` and pass it as a parameter to whatever requires it.

## Breaking Changes

No breaking changes since this is merely a refactor.

## Observations

There is a bit of an implicit assumption that if `config.EnableMetrics == true` then the registry provided as parameter is not `nil`.

