### PR TITLE
Include signature in message receiving logs

### DIFF
--- a/aggregator/message_blsagg.go
+++ b/aggregator/message_blsagg.go
@@ -472,7 +472,7 @@ func (mbas *MessageBlsAggregatorService) verifySignature(
 ) error {
 	_, ok := operatorsAvsStateDict[signedMessageDigest.OperatorId]
 	if !ok {
-		mbas.logger.Warn("Operator not found. Skipping message", "operator", fmt.Sprintf("%#v", signedMessageDigest.OperatorId))
+		mbas.logger.Warn("Operator not found. Skipping message", "operator", signedMessageDigest.OperatorId)
 		return OperatorNotPartOfMessageQuorumErrorFn(signedMessageDigest.OperatorId, signedMessageDigest.MessageDigest)
 	}
 

--- a/aggregator/rpc_server/server.go
+++ b/aggregator/rpc_server/server.go
@@ -2,7 +2,6 @@ package rpc_server
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/rpc"
 	"strings"
@@ -93,7 +92,7 @@ func mapErrors(err error) error {
 // reply doesn't need to be checked. If there are no errors, the task response is accepted
 // rpc framework forces a reply type to exist, so we put bool as a placeholder
 func (s *RpcServer) ProcessSignedCheckpointTaskResponse(signedCheckpointTaskResponse *messages.SignedCheckpointTaskResponse, reply *bool) error {
-	s.logger.Info("Received signed task response", "response", fmt.Sprintf("%#v", signedCheckpointTaskResponse))
+	s.logger.Info("Received signed task response", "response", signedCheckpointTaskResponse)
 	s.listener.IncTotalSignedCheckpointTaskResponse()
 	s.listener.ObserveLastMessageReceivedTime(signedCheckpointTaskResponse.OperatorId, CheckpointTaskResponseLabel)
 
@@ -113,7 +112,7 @@ func (s *RpcServer) ProcessSignedCheckpointTaskResponse(signedCheckpointTaskResp
 }
 
 func (s *RpcServer) ProcessSignedStateRootUpdateMessage(signedStateRootUpdateMessage *messages.SignedStateRootUpdateMessage, reply *bool) error {
-	s.logger.Info("Received signed state root update message", "updateMessage", fmt.Sprintf("%#v", signedStateRootUpdateMessage))
+	s.logger.Info("Received signed state root update message", "updateMessage", signedStateRootUpdateMessage)
 	s.listener.IncTotalSignedCheckpointTaskResponse()
 	s.listener.ObserveLastMessageReceivedTime(signedStateRootUpdateMessage.OperatorId, StateRootUpdateMessageLabel)
 
@@ -131,7 +130,7 @@ func (s *RpcServer) ProcessSignedStateRootUpdateMessage(signedStateRootUpdateMes
 }
 
 func (s *RpcServer) ProcessSignedOperatorSetUpdateMessage(signedOperatorSetUpdateMessage *messages.SignedOperatorSetUpdateMessage, reply *bool) error {
-	s.logger.Info("Received signed operator set update message", "message", fmt.Sprintf("%#v", signedOperatorSetUpdateMessage))
+	s.logger.Info("Received signed operator set update message", "message", signedOperatorSetUpdateMessage)
 
 	operatorId := signedOperatorSetUpdateMessage.OperatorId
 	s.listener.ObserveLastMessageReceivedTime(operatorId, OperatorSetUpdateMessageLabel)

--- a/operator/rpc_client.go
+++ b/operator/rpc_client.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"net/rpc"
 	"sync"
@@ -270,7 +269,7 @@ func (c *AggregatorRpcClient) tryResendFromDeque() {
 
 			entry.Retries++
 			if entry.Retries >= MaxRetries {
-				c.logger.Error("Max retries reached, dropping message", "message", fmt.Sprintf("%#v", message))
+				c.logger.Error("Max retries reached, dropping message", "message", message)
 				continue
 			}
 
@@ -331,7 +330,7 @@ func (c *AggregatorRpcClient) sendRequest(sendCb func() error) error {
 }
 
 func (c *AggregatorRpcClient) SendSignedCheckpointTaskResponseToAggregator(signedCheckpointTaskResponse *messages.SignedCheckpointTaskResponse) {
-	c.logger.Info("Sending signed task response header to aggregator", "signedCheckpointTaskResponse", fmt.Sprintf("%#v", signedCheckpointTaskResponse))
+	c.logger.Info("Sending signed task response header to aggregator", "signedCheckpointTaskResponse", signedCheckpointTaskResponse)
 
 	c.sendOperatorMessage(func() error {
 		var reply bool
@@ -353,7 +352,7 @@ func (c *AggregatorRpcClient) SendSignedCheckpointTaskResponseToAggregator(signe
 }
 
 func (c *AggregatorRpcClient) SendSignedStateRootUpdateToAggregator(signedStateRootUpdateMessage *messages.SignedStateRootUpdateMessage) {
-	c.logger.Info("Sending signed state root update message to aggregator", "signedStateRootUpdateMessage", fmt.Sprintf("%#v", signedStateRootUpdateMessage))
+	c.logger.Info("Sending signed state root update message to aggregator", "signedStateRootUpdateMessage", signedStateRootUpdateMessage)
 
 	c.sendOperatorMessage(func() error {
 		var reply bool
@@ -374,7 +373,7 @@ func (c *AggregatorRpcClient) SendSignedStateRootUpdateToAggregator(signedStateR
 }
 
 func (c *AggregatorRpcClient) SendSignedOperatorSetUpdateToAggregator(signedOperatorSetUpdateMessage *messages.SignedOperatorSetUpdateMessage) {
-	c.logger.Info("Sending operator set update message to aggregator", "signedOperatorSetUpdateMessage", fmt.Sprintf("%#v", signedOperatorSetUpdateMessage))
+	c.logger.Info("Sending operator set update message to aggregator", "signedOperatorSetUpdateMessage", signedOperatorSetUpdateMessage)
 
 	c.sendOperatorMessage(func() error {
 		var reply bool


### PR DESCRIPTION
## Current Behavior

Currently, when logging messages that contain a `bls.Signature` we're logging a pointer address rather than its contents.

## New Behavior

Whenever we log these messages we log their value rather that their representation

## Breaking Changes

This change should not introduce any breaking changes.

## Observations

The original code used `fmt.Sprintf("%#v", ...)` in the log calls which did not dereference the pointers. This behavior is present since #12 but there is no clear indication on why it was done that way.

