### PR TITLE
Fix SFFL title in docs

### DIFF
--- a/docs/docs/deployments.md
+++ b/docs/docs/deployments.md
@@ -8,7 +8,7 @@ sidebar_position: 5
 
 :::info
 
-While the opt-in process for NEAR NFFL is currently underway - see
+While the opt-in process for NFFL is currently underway - see
 [Registration](./operator/registration) - the testnet is not completely
 operational just yet.
 

--- a/docs/docs/operator/registration.md
+++ b/docs/docs/operator/registration.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Registration
 
-Here we'll go step-by-step on how to opt-in into NEAR NFFL. It's a quick and
+Here we'll go step-by-step on how to opt-in into NFFL. It's a quick and
 easy process that will allow you to start contributing to the network once the
 testnet starts functioning.
 

--- a/docs/docs/operator/setup.md
+++ b/docs/docs/operator/setup.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 :::info
 
-While the opt-in process for NEAR NFFL is currently underway - see
+While the opt-in process for NFFL is currently underway - see
 [Registration](./registration) - the testnet is not completely operational
 just yet, so it's currently not required that operators run a node. Keep an
 eye out for updates!
@@ -14,7 +14,7 @@ eye out for updates!
 :::
 
 This guide will walk you through the steps required to set up your operator
-node on the NEAR NFFL testnet. The testnet serves as a sandbox environment
+node on the NFFL testnet. The testnet serves as a sandbox environment
 for testing and development, allowing you to test both the AVS smart contracts
 and off-chain services. As the network is under active development, it's
 crucial to stay updated with the latest changes and keep your node in sync
@@ -22,7 +22,7 @@ with the network.
 
 ## Hardware Requirements
 
-A NEAR NFFL operator node consists of two main components: the AVS node
+A NFFL operator node consists of two main components: the AVS node
 software and a NEAR DA indexer. The AVS node software is a Go implementation
 of the AVS protocol, while the NEAR DA indexer is essentially a NEAR full node
 that indexes NEAR DA submissions on the NEAR blockchain.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,8 +8,8 @@ import {themes as prismThemes} from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'NEAR NFFL',
-  tagline: 'NEAR Fast Finality Layer',
+  title: 'NFFL',
+  tagline: 'Nuffle Fast Finality Layer',
   favicon: 'img/favicon.ico',
 
   url: 'https://nffl.nethermind.io',
@@ -48,7 +48,7 @@ const config = {
     ({
       image: 'img/near-sffl-social-card.jpg',
       navbar: {
-        title: 'NEAR NFFL',
+        title: 'NFFL',
         logo: {
           alt: 'NEAR Logo',
           src: 'img/near-icon.svg',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,8 +8,8 @@ import {themes as prismThemes} from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'NEAR SFFL',
-  tagline: 'NEAR Super Fast Finality Layer',
+  title: 'NEAR NFFL',
+  tagline: 'NEAR Fast Finality Layer',
   favicon: 'img/favicon.ico',
 
   url: 'https://nffl.nethermind.io',
@@ -48,7 +48,7 @@ const config = {
     ({
       image: 'img/near-sffl-social-card.jpg',
       navbar: {
-        title: 'NEAR SFFL',
+        title: 'NEAR NFFL',
         logo: {
           alt: 'NEAR Logo',
           src: 'img/near-icon.svg',


### PR DESCRIPTION
## Current Behavior

The current docs (https://nffl.nethermind.io) still show `NEAR SFFL` in the page title and navbar.

## New Behavior

The title and navbar show `NFFL` rather than `SFFL` (fixes https://github.com/NethermindEth/near-sffl/pull/255#issuecomment-2200686227)

## Breaking Changes

There should be no breaking changes.

## Observations

We missed this on #255
