### PR TITLE
Refactor indexer healthcheck for reliability

### DIFF
--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -26,7 +26,7 @@ RUN cargo build --release -p indexer
 FROM debian:bookworm-slim as runtime
 WORKDIR /indexer-app
 
-RUN apt update && apt install -yy openssl ca-certificates jq netcat-traditional httpie
+RUN apt update && apt install -yy openssl ca-certificates jq curl
 
 COPY --from=builder /tmp/indexer/target/release/indexer .
 COPY ./indexer/entrypoint.sh ./entrypoint.sh
@@ -35,18 +35,13 @@ RUN chmod +x ./entrypoint.sh
 EXPOSE 3030
 
 HEALTHCHECK --interval=20s --timeout=30s --retries=200 \
-  CMD nc -zv localhost 3030 && \
-      sh -c 'while true; do \
-        resp=$(http --ignore-stdin post http://localhost:3030 jsonrpc=2.0 method=status params:="[]" id=dontcare); \
-        if [ $? -ne 0 ]; then \
-          echo "Request failed with error: $resp" >&2; \
-          exit 1; \
-        fi; \
-        sync_status=$(echo $resp | jq -r ".result.sync_info.syncing"); \
-        if [ "$sync_status" = "false" ]; then \
-          exit 0; \
-        fi; \
-        sleep 1; \
-      done'
+  CMD curl -s -X POST -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","method":"block","params":{"finality":"optimistic"},"id":"dontcare"}' \
+      https://localhost:3000 | \
+    jq -e '(now - (.result.header.timestamp / 1000000000)) < 10' && \
+    curl -s -X POST -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","method":"status","params":[],"id":"dontcare"}' \
+      https://localhost:3000 | \
+    jq -e '.result.sync_info.syncing == false'
 
 ENTRYPOINT [ "./entrypoint.sh" ]

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -34,14 +34,14 @@ RUN chmod +x ./entrypoint.sh
 
 EXPOSE 3030
 
-HEALTHCHECK --interval=20s --timeout=30s --retries=200 \
-  CMD curl -s -X POST -H "Content-Type: application/json" \
-      -d '{"jsonrpc":"2.0","method":"block","params":{"finality":"optimistic"},"id":"dontcare"}' \
-      https://localhost:3000 | \
-    jq -e '(now - (.result.header.timestamp / 1000000000)) < 10' && \
-    curl -s -X POST -H "Content-Type: application/json" \
-      -d '{"jsonrpc":"2.0","method":"status","params":[],"id":"dontcare"}' \
-      https://localhost:3000 | \
-    jq -e '.result.sync_info.syncing == false'
+HEALTHCHECK --interval=20s --timeout=30s --retries=10000 \
+  CMD (curl -f -s -X POST -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"block","params":{"finality":"optimistic"},"id":"dontcare"}' \
+    http://localhost:3030 | \
+  jq -es 'if . == [] then null else .[] | (now - (.result.header.timestamp / 1000000000)) < 10 end') && \
+  (curl -f -s -X POST -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"status","params":[],"id":"dontcare"}' \
+    http://localhost:3030 | \
+  jq -es 'if . == [] then null else .[] | .result.sync_info.syncing == false end')
 
 ENTRYPOINT [ "./entrypoint.sh" ]


### PR DESCRIPTION
## Current Behavior

The current indexer container healthcheck is not entirely reliable - very rarely the container is marked as healthy before actually being synced. It also does an unnecessary loop for checking the node state.

Related to #242.

## New Behavior

Now the healthcheck also tries and fetches the current block, checking it's at most 10s old, before checking the node syncing state. It's also does not loop anymore.

## Breaking Changes

None

