### PR TITLE
Clear NEAR DA data on docker compose test env reset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     depends_on:
       rollup0-anvil:
         condition: service_healthy
-      indexer-setup:
+      near-da-deploy:
         condition: service_completed_successfully
     expose:
       - 9091
@@ -125,7 +125,7 @@ services:
     depends_on:
       rollup1-anvil:
         condition: service_healthy
-      indexer-setup:
+      near-da-deploy:
         condition: service_completed_successfully
     expose:
       - 9091
@@ -146,6 +146,8 @@ services:
       rmq:
         condition: service_healthy
       mainnet-anvil-setup:
+        condition: service_completed_successfully
+      indexer-setup:
         condition: service_completed_successfully
     ports:
       - "3030:3030"
@@ -171,8 +173,23 @@ services:
       - near-sffl
 
   indexer-setup:
-    image: node:16
+    image: debian:bookworm
     container_name: near-sffl-indexer-setup
+    volumes:
+      - near_cli_data:/near-cli
+      - near_cli_keys:/root/.near-credentials
+    entrypoint: sh
+    command:
+      - -c
+      - |
+        rm -rf /near-cli/*
+        rm -rf /root/.near-credentials/*
+    networks:
+      - near-sffl
+
+  near-da-deploy:
+    image: node:16
+    container_name: near-sffl-near-da-deploy
     depends_on:
       indexer:
         condition: service_healthy


### PR DESCRIPTION
## Current Behavior

NEAR DA data was not being cleared on a docker compose test env reset. The usual fix for this would be resetting the volumes whenever resetting - `docker compose down -v` or such. Still, this may pass unnoticed and cause some confusion.

A related PR is #267.

## New Behavior

The above issue is prevented by clearing the relevant data on the `indexer_setup` service. So, when re-upping it should be clean even if the volumes were not reset.

## Breaking Changes

None

