### PR TITLE
Fix block lock copying

### DIFF
--- a/operator/attestor/notifier_test.go
+++ b/operator/attestor/notifier_test.go
@@ -26,7 +26,7 @@ func generateBlockData() consumer.BlockData {
 
 	return consumer.BlockData{
 		RollupId: randomRollupId,
-		Block:    *types.NewBlockWithHeader(&header),
+		Block:    types.NewBlockWithHeader(&header),
 	}
 }
 

--- a/operator/consumer/consumer.go
+++ b/operator/consumer/consumer.go
@@ -46,7 +46,7 @@ type BlockData struct {
 	RollupId      uint32
 	Commitment    Commitment
 	TransactionId TransactionId
-	Block         types.Block
+	Block         *types.Block
 }
 
 type Consumerer interface {

--- a/operator/consumer/queues_listener.go
+++ b/operator/consumer/queues_listener.go
@@ -130,7 +130,7 @@ func (l *QueuesListener) listen(ctx context.Context, rollupId uint32, rollupData
 						RollupId:      rollupId,
 						TransactionId: publishPayload.TransactionId,
 						Commitment:    blob.Commitment,
-						Block:         *block,
+						Block:         block,
 					}
 
 					l.logger.Info(

--- a/operator/operator_test.go
+++ b/operator/operator_test.go
@@ -165,7 +165,7 @@ func TestOperator(t *testing.T) {
 		avsManager.operatorSetUpdateChan <- operatorSetUpdate
 		mockConsumer.MockReceiveBlockData(consumer.BlockData{
 			RollupId: signedStateRootUpdateMessage.Message.RollupId,
-			Block:    *block,
+			Block:    block,
 		})
 
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
## Current Behavior

In some cases, geth's `types.Block` are copied - mostly because of copying our `BlockData` instances. This is not being problematic in any sense since these locks aren't being used, but it's a small fix anyway.

## New Behavior

`BlockData` now includes a `types.Block` as a pointer, which is even more ideal considering how much data that struct holds. Thus, no copies even when copying `BlockData`, which should still be okay.

## Breaking Changes

Not a breaking change.

