### PR TITLE
Update nearcore to v2.1.0-rc.1

### DIFF
--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -26,12 +26,12 @@ tracing = { version = "0.1.36", features = ["std"] }
 thiserror = "1.0.56"
 anyhow = "1.0.79"
 
-near-indexer = { git = "https://github.com/near/nearcore", rev = "08941a3c070eca2e6163a4ad1eaed1f0d3ee233c" }
-near-client = { git = "https://github.com/near/nearcore", rev = "08941a3c070eca2e6163a4ad1eaed1f0d3ee233c" }
-near-o11y = { git = "https://github.com/near/nearcore", rev = "08941a3c070eca2e6163a4ad1eaed1f0d3ee233c" }
-near-client-primitives = { git = "https://github.com/near/nearcore", rev = "08941a3c070eca2e6163a4ad1eaed1f0d3ee233c" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "696a8464b76c6cee7d2a074a4ab838f474e70143" }
+near-client = { git = "https://github.com/near/nearcore", rev = "696a8464b76c6cee7d2a074a4ab838f474e70143" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "696a8464b76c6cee7d2a074a4ab838f474e70143" }
+near-client-primitives = { git = "https://github.com/near/nearcore", rev = "696a8464b76c6cee7d2a074a4ab838f474e70143" }
 borsh = { version = "1.0.0", features = ["derive", "rc"] }
 serde_yaml = "0.9.34"
 
 [dev-dependencies]
-near-crypto = { git = "https://github.com/near/nearcore", rev = "08941a3c070eca2e6163a4ad1eaed1f0d3ee233c" }
+near-crypto = { git = "https://github.com/near/nearcore", rev = "696a8464b76c6cee7d2a074a4ab838f474e70143" }

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.77 AS builder
+FROM rust:1.79 AS builder
 WORKDIR /tmp/indexer
 
 # Copy from nearcore:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.77.0"
+channel = "1.79.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
## Current Behavior

There should be a new protocol version going live next week through v2.1.0-rc.1.

## New Behavior

Updates Rust to 1.79 and the nearcore refs to the 2.1.0-rc.1 reference.

## Breaking Changes

No a breaking changes.

