### PR TITLE
Update AVS metadata with Nuffle fields

### DIFF
--- a/static/avs_metadata.json
+++ b/static/avs_metadata.json
@@ -1,7 +1,7 @@
 {
-    "name": "NEAR Fast Finality Layer",
+    "name": "Nuffle Fast Finality Layer",
     "website": "https://nffl.nethermind.io",
-    "description": "The NEAR Fast Finality Layer (NFFL) is a protocol designed to greatly enhance cross-chain communication by providing faster finality for rollups, leveraging the flexibility of NEAR DA and the strong economic security of an AVS.",
+    "description": "The Nuffle Fast Finality Layer (NFFL) is a protocol designed to greatly enhance cross-chain communication by providing faster finality for rollups, leveraging the flexibility of NEAR DA and the strong economic security of an AVS.",
     "logo": "https://raw.githubusercontent.com/NethermindEth/near-sffl/main/static/logo.png",
     "twitter": "https://twitter.com/NEARProtocol"
 }

--- a/static/avs_metadata.json
+++ b/static/avs_metadata.json
@@ -3,5 +3,5 @@
     "website": "https://nffl.nethermind.io",
     "description": "The Nuffle Fast Finality Layer (NFFL) is a protocol designed to greatly enhance cross-chain communication by providing faster finality for rollups, leveraging the flexibility of NEAR DA and the strong economic security of an AVS.",
     "logo": "https://raw.githubusercontent.com/NethermindEth/near-sffl/main/static/logo.png",
-    "twitter": "https://twitter.com/NEARProtocol"
+    "twitter": "https://twitter.com/nufflelabs"
 }


### PR DESCRIPTION
## Current Behavior

NFFL was described as "NEAR Fast Finality Layer" and the twitter URL was NEAR's.

## New Behavior

NFFL is now described as "Nuffle Fast Finality Layer" and the twitter URL is now Nuffle Lab's.

## Breaking Changes

None.


