### PR TITLE
Submit checkpoint aggregation on finished aggregation process

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -286,7 +286,9 @@ func (agg *Aggregator) Start(ctx context.Context) error {
 			return agg.Close()
 		case blsAggServiceResp := <-agg.taskBlsAggregationService.GetResponseChannel():
 			agg.logger.Info("Received response from taskBlsAggregationService", "blsAggServiceResp", blsAggServiceResp)
-			go agg.sendAggregatedResponseToContract(blsAggServiceResp)
+			if blsAggServiceResp.Finished {
+				go agg.sendAggregatedResponseToContract(blsAggServiceResp)
+			}
 		case blsAggServiceResp := <-agg.stateRootUpdateBlsAggregationService.GetResponseChannel():
 			agg.logger.Info("Received response from stateRootUpdateBlsAggregationService", "blsAggServiceResp", blsAggServiceResp)
 			agg.handleStateRootUpdateReachedQuorum(blsAggServiceResp)

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -35,7 +35,7 @@ const (
 	// this hardcoded here because it's also hardcoded in the contracts, but should
 	// ideally be fetched from the contracts
 	taskChallengeWindowBlock          = 100
-	taksResponseSubmissionBufferBlock = 15
+	taskResponseSubmissionBufferBlock = 15
 	taskAggregationTimeout            = 1 * time.Minute
 	blockTime                         = 12 * time.Second
 	avsName                           = "super-fast-finality-layer"
@@ -413,7 +413,7 @@ func (agg *Aggregator) sendNewCheckpointTask() {
 		quorumThresholds[i] = types.TASK_AGGREGATION_QUORUM_THRESHOLD
 	}
 
-	taskTimeToExpiry := (taskChallengeWindowBlock-taksResponseSubmissionBufferBlock)*blockTime - taskAggregationTimeout
+	taskTimeToExpiry := (taskChallengeWindowBlock-taskResponseSubmissionBufferBlock)*blockTime - taskAggregationTimeout
 	err = agg.taskBlsAggregationService.InitializeMessageIfNotExists(
 		messages.CheckpointTaskResponse{ReferenceTaskIndex: taskIndex}.Key(),
 		core.ConvertBytesToQuorumNumbers(newTask.QuorumNumbers),

--- a/aggregator/blsagg/message_blsagg.go
+++ b/aggregator/blsagg/message_blsagg.go
@@ -453,7 +453,7 @@ func (mbas *MessageBlsAggregatorService) getMessageBlsAggregationResponse(messag
 			Message:               message,
 			MessageKey:            message.Key(),
 			Status:                MessageBlsAggregationStatusNone,
-			Finished:              false,
+			Finished:              forceFinished,
 			Err:                   MessageNotFoundErrorFn(messageDigest),
 		}
 	}
@@ -465,7 +465,7 @@ func (mbas *MessageBlsAggregatorService) getMessageBlsAggregationResponse(messag
 			Message:               message,
 			MessageKey:            message.Key(),
 			Status:                MessageBlsAggregationStatusNone,
-			Finished:              false,
+			Finished:              forceFinished,
 			Err:                   err,
 		}
 	}
@@ -485,7 +485,7 @@ func (mbas *MessageBlsAggregatorService) getMessageBlsAggregationResponse(messag
 			Message:               message,
 			MessageKey:            message.Key(),
 			Status:                MessageBlsAggregationStatusNone,
-			Finished:              false,
+			Finished:              forceFinished,
 			Err:                   err,
 		}
 	}
@@ -511,7 +511,7 @@ func (mbas *MessageBlsAggregatorService) getMessageBlsAggregationResponse(messag
 			Message:               message,
 			MessageKey:            message.Key(),
 			Status:                MessageBlsAggregationStatusNone,
-			Finished:              false,
+			Finished:              forceFinished,
 			Err:                   err,
 		}
 	}


### PR DESCRIPTION
## Current Behavior

With the latest change on #282, checkpoint aggregations are submitted as soon as they're ready.

## New Behavior

This PR makes is so the aggregations are only submitted when the aggregation process is finished. This should potentially save us some gas, since even if quorum is reached it waits a bit and aggregates more signatures, which decreases the verification cost.

## Breaking Changes

None.
