### PR TITLE
Delete intermediate aggregations on DB replace

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -454,12 +454,12 @@ func (agg *Aggregator) handleStateRootUpdateReachedQuorum(blsAggServiceResp blsa
 
 	agg.logger.Info("Storing state root update", "digest", blsAggServiceResp.MessageDigest, "status", blsAggServiceResp.Status)
 
-	err := agg.msgDb.StoreStateRootUpdate(msg)
+	msgModel, err := agg.msgDb.StoreStateRootUpdate(msg)
 	if err != nil {
 		agg.logger.Error("Aggregator could not store message")
 		return
 	}
-	err = agg.msgDb.StoreStateRootUpdateAggregation(msg, blsAggServiceResp.MessageBlsAggregation)
+	err = agg.msgDb.StoreStateRootUpdateAggregation(msgModel, blsAggServiceResp.MessageBlsAggregation)
 	if err != nil {
 		agg.logger.Error("Aggregator could not store message aggregation")
 		return
@@ -499,12 +499,12 @@ func (agg *Aggregator) handleOperatorSetUpdateReachedQuorum(ctx context.Context,
 
 	agg.logger.Info("Storing operator set update", "digest", blsAggServiceResp.MessageDigest, "status", blsAggServiceResp.Status)
 
-	err := agg.msgDb.StoreOperatorSetUpdate(msg)
+	msgModel, err := agg.msgDb.StoreOperatorSetUpdate(msg)
 	if err != nil {
 		agg.logger.Error("Aggregator could not store message")
 		return
 	}
-	err = agg.msgDb.StoreOperatorSetUpdateAggregation(msg, blsAggServiceResp.MessageBlsAggregation)
+	err = agg.msgDb.StoreOperatorSetUpdateAggregation(msgModel, blsAggServiceResp.MessageBlsAggregation)
 	if err != nil {
 		agg.logger.Error("Aggregator could not store message aggregation")
 		return

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/NethermindEth/near-sffl/aggregator/blsagg"
 	dbmocks "github.com/NethermindEth/near-sffl/aggregator/database/mocks"
+	"github.com/NethermindEth/near-sffl/aggregator/database/models"
 	aggmocks "github.com/NethermindEth/near-sffl/aggregator/mocks"
 	"github.com/NethermindEth/near-sffl/aggregator/types"
 	taskmanager "github.com/NethermindEth/near-sffl/contracts/bindings/SFFLTaskManager"
@@ -116,8 +117,11 @@ func TestHandleStateRootUpdateAggregationReachedQuorum(t *testing.T) {
 		Finished: true,
 	}
 
-	mockMsgDb.EXPECT().StoreStateRootUpdate(msg)
-	mockMsgDb.EXPECT().StoreStateRootUpdateAggregation(msg, blsAggServiceResp.MessageBlsAggregation)
+	model := models.NewStateRootUpdateMessageModel(msg)
+
+	// get first return from StoreStateRootUpdate and use it as first argument on StoreStateRootUpdateAggregation
+	mockMsgDb.EXPECT().StoreStateRootUpdate(msg).Return(&model, nil)
+	mockMsgDb.EXPECT().StoreStateRootUpdateAggregation(&model, blsAggServiceResp.MessageBlsAggregation)
 
 	aggregator.handleStateRootUpdateReachedQuorum(blsAggServiceResp)
 }
@@ -144,8 +148,10 @@ func TestHandleOperatorSetUpdateAggregationReachedQuorum(t *testing.T) {
 		Finished: true,
 	}
 
-	mockMsgDb.EXPECT().StoreOperatorSetUpdate(msg)
-	mockMsgDb.EXPECT().StoreOperatorSetUpdateAggregation(msg, blsAggServiceResp.MessageBlsAggregation)
+	msgModel := models.NewOperatorSetUpdateMessageModel(msg)
+
+	mockMsgDb.EXPECT().StoreOperatorSetUpdate(msg).Return(&msgModel, nil)
+	mockMsgDb.EXPECT().StoreOperatorSetUpdateAggregation(&msgModel, blsAggServiceResp.MessageBlsAggregation)
 
 	signatureInfo := blsAggServiceResp.ExtractBindingRollup()
 	mockRollupBroadcaster.EXPECT().BroadcastOperatorSetUpdate(context.Background(), msg, signatureInfo)

--- a/aggregator/database/database.go
+++ b/aggregator/database/database.go
@@ -41,6 +41,7 @@ type Database struct {
 }
 
 var _ core.Metricable = (*Database)(nil)
+var _ Databaser = (*Database)(nil)
 
 func NewDatabase(dbPath string) (*Database, error) {
 	logger := logger.New(

--- a/aggregator/database/database.go
+++ b/aggregator/database/database.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
 
 	"github.com/NethermindEth/near-sffl/aggregator/database/models"
@@ -120,8 +119,9 @@ func (d *Database) StoreStateRootUpdate(stateRootUpdateMessage messages.StateRoo
 	}
 
 	tx := d.db.
-		Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "rollup_id"}, {Name: "block_height"}}, UpdateAll: true}).
-		Create(&model)
+		Where("rollup_id = ?", stateRootUpdateMessage.RollupId).
+		Where("block_height = ?", stateRootUpdateMessage.BlockHeight).
+		FirstOrCreate(&model)
 
 	return &model, tx.Error
 }
@@ -199,8 +199,8 @@ func (d *Database) StoreOperatorSetUpdate(operatorSetUpdateMessage messages.Oper
 	}
 
 	tx := d.db.
-		Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "update_id"}}, UpdateAll: true}).
-		Create(&model)
+		Where("update_id = ?", operatorSetUpdateMessage.Id).
+		FirstOrCreate(&model)
 
 	return &model, tx.Error
 }

--- a/aggregator/database/database.go
+++ b/aggregator/database/database.go
@@ -148,11 +148,13 @@ func (d *Database) StoreStateRootUpdateAggregation(stateRootUpdateMessage messag
 	model := models.NewMessageBlsAggregationModel(aggregation)
 
 	err := d.db.
+		Unscoped().
 		Clauses(clause.OnConflict{UpdateAll: true}).
 		Model(&models.StateRootUpdateMessage{}).
 		Where("rollup_id = ?", stateRootUpdateMessage.RollupId).
 		Where("block_height = ?", stateRootUpdateMessage.BlockHeight).
 		Association("Aggregation").
+		Unscoped().
 		Replace(&model)
 	if err != nil {
 		return err
@@ -225,10 +227,12 @@ func (d *Database) StoreOperatorSetUpdateAggregation(operatorSetUpdateMessage me
 	model := models.NewMessageBlsAggregationModel(aggregation)
 
 	err := d.db.
+		Unscoped().
 		Clauses(clause.OnConflict{UpdateAll: true}).
 		Model(&models.OperatorSetUpdateMessage{}).
 		Where("update_id = ?", operatorSetUpdateMessage.Id).
 		Association("Aggregation").
+		Unscoped().
 		Replace(&model)
 	if err != nil {
 		return err
@@ -266,7 +270,7 @@ func (d *Database) FetchCheckpointMessages(fromTimestamp uint64, toTimestamp uin
 		return nil, errors.New("timestamp does not fit in int64")
 	}
 
-	if (toTimestamp < fromTimestamp) {
+	if toTimestamp < fromTimestamp {
 		return nil, errors.New("toTimestamp is less than fromTimestamp")
 	}
 

--- a/aggregator/database/database.go
+++ b/aggregator/database/database.go
@@ -31,6 +31,7 @@ type Databaser interface {
 	StoreOperatorSetUpdateAggregation(operatorSetUpdateMessage *models.OperatorSetUpdateMessage, aggregation messages.MessageBlsAggregation) error
 	FetchOperatorSetUpdateAggregation(id uint64) (*messages.MessageBlsAggregation, error)
 	FetchCheckpointMessages(fromTimestamp uint64, toTimestamp uint64) (*messages.CheckpointMessages, error)
+	DB() *gorm.DB
 }
 
 type Database struct {

--- a/aggregator/database/database_test.go
+++ b/aggregator/database/database_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/NethermindEth/near-sffl/aggregator/database"
+	"github.com/NethermindEth/near-sffl/aggregator/database/models"
 	coretypes "github.com/NethermindEth/near-sffl/core/types"
 	"github.com/NethermindEth/near-sffl/core/types/messages"
 	"github.com/NethermindEth/near-sffl/tests"
@@ -43,7 +44,7 @@ func TestStoreAndFetchStateRootUpdate(t *testing.T) {
 		StateRoot:           tests.Keccak256(6),
 	}
 
-	err = db.StoreStateRootUpdate(value)
+	_, err = db.StoreStateRootUpdate(value)
 	assert.Nil(t, err)
 
 	entry, err := db.FetchStateRootUpdate(value.RollupId, value.BlockHeight)
@@ -81,7 +82,7 @@ func TestStoreAndFetchStateRootUpdateAggregation(t *testing.T) {
 		StateRoot:           tests.Keccak256(6),
 	}
 
-	err = db.StoreStateRootUpdate(msg)
+	msgModel, err := db.StoreStateRootUpdate(msg)
 	assert.Nil(t, err)
 
 	msgDigest, err := msg.Digest()
@@ -91,7 +92,7 @@ func TestStoreAndFetchStateRootUpdateAggregation(t *testing.T) {
 		MessageDigest: msgDigest,
 	}
 
-	err = db.StoreStateRootUpdateAggregation(msg, value)
+	err = db.StoreStateRootUpdateAggregation(msgModel, value)
 	assert.Nil(t, err)
 
 	entry, err := db.FetchStateRootUpdateAggregation(msg.RollupId, msg.BlockHeight)
@@ -99,6 +100,46 @@ func TestStoreAndFetchStateRootUpdateAggregation(t *testing.T) {
 	assert.NotNil(t, entry)
 
 	assert.Equal(t, *entry, value)
+}
+
+func TestStateRootUpdateAggregationReplace(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	db, err := database.NewDatabase(":memory:")
+	assert.Nil(t, err)
+
+	msg := messages.StateRootUpdateMessage{
+		RollupId:            1,
+		BlockHeight:         2,
+		Timestamp:           3,
+		NearDaTransactionId: tests.Keccak256(4),
+		NearDaCommitment:    tests.Keccak256(5),
+		StateRoot:           tests.Keccak256(6),
+	}
+
+	msgModel, err := db.StoreStateRootUpdate(msg)
+	assert.Nil(t, err)
+
+	msgDigest, err := msg.Digest()
+	assert.Nil(t, err)
+
+	value := messages.MessageBlsAggregation{
+		MessageDigest: msgDigest,
+	}
+
+	err = db.StoreStateRootUpdateAggregation(msgModel, value)
+	assert.Nil(t, err)
+
+	err = db.StoreStateRootUpdateAggregation(msgModel, value)
+	assert.Nil(t, err)
+
+	err = db.StoreStateRootUpdateAggregation(msgModel, value)
+	assert.Nil(t, err)
+
+	var count int64
+	db.DB().Model(&models.MessageBlsAggregation{}).Count(&count)
+	assert.Equal(t, count, int64(1))
 }
 
 func TestFetchUnknownOperatorSetUpdate(t *testing.T) {
@@ -128,7 +169,7 @@ func TestStoreAndFetchOperatorSetUpdate(t *testing.T) {
 		},
 	}
 
-	err = db.StoreOperatorSetUpdate(value)
+	_, err = db.StoreOperatorSetUpdate(value)
 	assert.Nil(t, err)
 
 	entry, err := db.FetchOperatorSetUpdate(value.Id)
@@ -165,7 +206,7 @@ func TestStoreAndFetchOperatorSetUpdateAggregation(t *testing.T) {
 		},
 	}
 
-	err = db.StoreOperatorSetUpdate(msg)
+	msgModel, err := db.StoreOperatorSetUpdate(msg)
 	assert.Nil(t, err)
 
 	msgDigest, err := msg.Digest()
@@ -175,7 +216,7 @@ func TestStoreAndFetchOperatorSetUpdateAggregation(t *testing.T) {
 		MessageDigest: msgDigest,
 	}
 
-	err = db.StoreOperatorSetUpdateAggregation(msg, value)
+	err = db.StoreOperatorSetUpdateAggregation(msgModel, value)
 	assert.Nil(t, err)
 
 	entry, err := db.FetchOperatorSetUpdateAggregation(msg.Id)
@@ -183,6 +224,45 @@ func TestStoreAndFetchOperatorSetUpdateAggregation(t *testing.T) {
 	assert.NotNil(t, entry)
 
 	assert.Equal(t, *entry, value)
+}
+
+func TestOperatorSetUpdateAggregationReplace(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	db, err := database.NewDatabase(":memory:")
+	assert.Nil(t, err)
+
+	msg := messages.OperatorSetUpdateMessage{
+		Id:        1,
+		Timestamp: 2,
+		Operators: []coretypes.RollupOperator{
+			{Pubkey: bls.NewG1Point(big.NewInt(3), big.NewInt(4)), Weight: big.NewInt(5)},
+		},
+	}
+
+	msgModel, err := db.StoreOperatorSetUpdate(msg)
+	assert.Nil(t, err)
+
+	msgDigest, err := msg.Digest()
+	assert.Nil(t, err)
+
+	value := messages.MessageBlsAggregation{
+		MessageDigest: msgDigest,
+	}
+
+	err = db.StoreOperatorSetUpdateAggregation(msgModel, value)
+	assert.Nil(t, err)
+
+	err = db.StoreOperatorSetUpdateAggregation(msgModel, value)
+	assert.Nil(t, err)
+
+	err = db.StoreOperatorSetUpdateAggregation(msgModel, value)
+	assert.Nil(t, err)
+
+	var count int64
+	db.DB().Model(&models.MessageBlsAggregation{}).Count(&count)
+	assert.Equal(t, count, int64(1))
 }
 
 func TestFetchCheckpointMessages(t *testing.T) {
@@ -254,28 +334,31 @@ func TestFetchCheckpointMessages(t *testing.T) {
 		MessageDigest: msgDigest4,
 	}
 
-	err = db.StoreStateRootUpdate(msg1)
+	var stateRootUpdateMsgModel *models.StateRootUpdateMessage
+	var operatorSetUpdateMsgModel *models.OperatorSetUpdateMessage
+
+	stateRootUpdateMsgModel, err = db.StoreStateRootUpdate(msg1)
 	assert.Nil(t, err)
 
-	err = db.StoreStateRootUpdateAggregation(msg1, aggregation1)
+	err = db.StoreStateRootUpdateAggregation(stateRootUpdateMsgModel, aggregation1)
 	assert.Nil(t, err)
 
-	err = db.StoreStateRootUpdate(msg2)
+	stateRootUpdateMsgModel, err = db.StoreStateRootUpdate(msg2)
 	assert.Nil(t, err)
 
-	err = db.StoreStateRootUpdateAggregation(msg2, aggregation2)
+	err = db.StoreStateRootUpdateAggregation(stateRootUpdateMsgModel, aggregation2)
 	assert.Nil(t, err)
 
-	err = db.StoreOperatorSetUpdate(msg3)
+	operatorSetUpdateMsgModel, err = db.StoreOperatorSetUpdate(msg3)
 	assert.Nil(t, err)
 
-	err = db.StoreOperatorSetUpdateAggregation(msg3, aggregation3)
+	err = db.StoreOperatorSetUpdateAggregation(operatorSetUpdateMsgModel, aggregation3)
 	assert.Nil(t, err)
 
-	err = db.StoreOperatorSetUpdate(msg4)
+	operatorSetUpdateMsgModel, err = db.StoreOperatorSetUpdate(msg4)
 	assert.Nil(t, err)
 
-	err = db.StoreOperatorSetUpdateAggregation(msg4, aggregation4)
+	err = db.StoreOperatorSetUpdateAggregation(operatorSetUpdateMsgModel, aggregation4)
 	assert.Nil(t, err)
 
 	result, err := db.FetchCheckpointMessages(0, 3)
@@ -361,7 +444,7 @@ func TestStoreStateRootUpdate_LargeMsgValues(t *testing.T) {
 		NearDaCommitment:    [32]byte{0xFF},
 		StateRoot:           [32]byte{0xFF},
 	}
-	err = db.StoreStateRootUpdate(msg)
+	_, err = db.StoreStateRootUpdate(msg)
 	assert.Nil(t, err)
 
 	stored, err := db.FetchStateRootUpdate(math.MaxUint32, math.MaxUint64)

--- a/aggregator/database/database_test.go
+++ b/aggregator/database/database_test.go
@@ -131,8 +131,18 @@ func TestStateRootUpdateAggregationReplace(t *testing.T) {
 	err = db.StoreStateRootUpdateAggregation(msgModel, value)
 	assert.Nil(t, err)
 
+	msgModel, err = db.StoreStateRootUpdate(msg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, msgModel.AggregationId, uint32(1))
+
 	err = db.StoreStateRootUpdateAggregation(msgModel, value)
 	assert.Nil(t, err)
+
+	msgModel, err = db.StoreStateRootUpdate(msg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, msgModel.AggregationId, uint32(2))
 
 	err = db.StoreStateRootUpdateAggregation(msgModel, value)
 	assert.Nil(t, err)
@@ -254,8 +264,18 @@ func TestOperatorSetUpdateAggregationReplace(t *testing.T) {
 	err = db.StoreOperatorSetUpdateAggregation(msgModel, value)
 	assert.Nil(t, err)
 
+	msgModel, err = db.StoreOperatorSetUpdate(msg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, msgModel.AggregationId, uint32(1))
+
 	err = db.StoreOperatorSetUpdateAggregation(msgModel, value)
 	assert.Nil(t, err)
+
+	msgModel, err = db.StoreOperatorSetUpdate(msg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, msgModel.AggregationId, uint32(2))
 
 	err = db.StoreOperatorSetUpdateAggregation(msgModel, value)
 	assert.Nil(t, err)

--- a/aggregator/database/mocks/database.go
+++ b/aggregator/database/mocks/database.go
@@ -15,6 +15,7 @@ import (
 	messages "github.com/NethermindEth/near-sffl/core/types/messages"
 	prometheus "github.com/prometheus/client_golang/prometheus"
 	gomock "go.uber.org/mock/gomock"
+	gorm "gorm.io/gorm"
 )
 
 // MockDatabaser is a mock of Databaser interface.
@@ -52,6 +53,20 @@ func (m *MockDatabaser) Close() error {
 func (mr *MockDatabaserMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDatabaser)(nil).Close))
+}
+
+// DB mocks base method.
+func (m *MockDatabaser) DB() *gorm.DB {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DB")
+	ret0, _ := ret[0].(*gorm.DB)
+	return ret0
+}
+
+// DB indicates an expected call of DB.
+func (mr *MockDatabaserMockRecorder) DB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DB", reflect.TypeOf((*MockDatabaser)(nil).DB))
 }
 
 // EnableMetrics mocks base method.

--- a/aggregator/database/mocks/database.go
+++ b/aggregator/database/mocks/database.go
@@ -5,13 +5,13 @@
 //
 //	mockgen -destination=./mocks/database.go -package=mocks github.com/NethermindEth/near-sffl/aggregator/database Databaser
 //
-
 // Package mocks is a generated GoMock package.
 package mocks
 
 import (
 	reflect "reflect"
 
+	models "github.com/NethermindEth/near-sffl/aggregator/database/models"
 	messages "github.com/NethermindEth/near-sffl/core/types/messages"
 	prometheus "github.com/prometheus/client_golang/prometheus"
 	gomock "go.uber.org/mock/gomock"
@@ -144,11 +144,12 @@ func (mr *MockDatabaserMockRecorder) FetchStateRootUpdateAggregation(arg0, arg1 
 }
 
 // StoreOperatorSetUpdate mocks base method.
-func (m *MockDatabaser) StoreOperatorSetUpdate(arg0 messages.OperatorSetUpdateMessage) error {
+func (m *MockDatabaser) StoreOperatorSetUpdate(arg0 messages.OperatorSetUpdateMessage) (*models.OperatorSetUpdateMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreOperatorSetUpdate", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*models.OperatorSetUpdateMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // StoreOperatorSetUpdate indicates an expected call of StoreOperatorSetUpdate.
@@ -158,7 +159,7 @@ func (mr *MockDatabaserMockRecorder) StoreOperatorSetUpdate(arg0 any) *gomock.Ca
 }
 
 // StoreOperatorSetUpdateAggregation mocks base method.
-func (m *MockDatabaser) StoreOperatorSetUpdateAggregation(arg0 messages.OperatorSetUpdateMessage, arg1 messages.MessageBlsAggregation) error {
+func (m *MockDatabaser) StoreOperatorSetUpdateAggregation(arg0 *models.OperatorSetUpdateMessage, arg1 messages.MessageBlsAggregation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreOperatorSetUpdateAggregation", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -172,11 +173,12 @@ func (mr *MockDatabaserMockRecorder) StoreOperatorSetUpdateAggregation(arg0, arg
 }
 
 // StoreStateRootUpdate mocks base method.
-func (m *MockDatabaser) StoreStateRootUpdate(arg0 messages.StateRootUpdateMessage) error {
+func (m *MockDatabaser) StoreStateRootUpdate(arg0 messages.StateRootUpdateMessage) (*models.StateRootUpdateMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreStateRootUpdate", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*models.StateRootUpdateMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // StoreStateRootUpdate indicates an expected call of StoreStateRootUpdate.
@@ -186,7 +188,7 @@ func (mr *MockDatabaserMockRecorder) StoreStateRootUpdate(arg0 any) *gomock.Call
 }
 
 // StoreStateRootUpdateAggregation mocks base method.
-func (m *MockDatabaser) StoreStateRootUpdateAggregation(arg0 messages.StateRootUpdateMessage, arg1 messages.MessageBlsAggregation) error {
+func (m *MockDatabaser) StoreStateRootUpdateAggregation(arg0 *models.StateRootUpdateMessage, arg1 messages.MessageBlsAggregation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreStateRootUpdateAggregation", arg0, arg1)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
## Current Behavior

We are keeping intermediate aggregations through GORM's Replace leaving them as orphans instead of deleting them.

## New Behavior

This PR introduces some changes to make it so aggregations are deleted when being replaced on incremental aggregation.

## Breaking Changes

None.

