### PR TITLE
Ignore mismatching digests after threshold reached

### DIFF
--- a/aggregator/blsagg/message_blsagg.go
+++ b/aggregator/blsagg/message_blsagg.go
@@ -306,6 +306,12 @@ func (mbas *MessageBlsAggregatorService) handleSignedMessageThresholdReached(
 		case signedMessage := <-signedMessageC:
 			mbas.logger.Debug("Message goroutine received new signed message", "key", messageKey)
 
+			if signedMessage.MessageDigest != messageDigest {
+				mbas.logger.Warn("Ignored signed message with non-majority digest", "expected", messageDigest, "got", signedMessage.MessageDigest)
+				signedMessage.SignatureVerificationErrorC <- nil
+				continue
+			}
+
 			err := mbas.handleSignedMessageDigest(signedMessage, validationInfo)
 			signedMessage.SignatureVerificationErrorC <- err
 			if err != nil {


### PR DESCRIPTION
## Current Behavior

After threshold was reached, `MessageBlsAggregationService` also posted responses even though the message content differed for the same key.

## New Behavior

With this PR, after the threshold was reached, which is assumed to be a majority (and enforced in the code), non-majority message signatures are ignored in the aggregation.

## Breaking Changes

None.

