### PR TITLE
Fix pubkey sorting on aggregations

### DIFF
--- a/aggregator/blsagg/message_blsagg.go
+++ b/aggregator/blsagg/message_blsagg.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 	"sync"
 	"time"
 
@@ -483,6 +484,18 @@ func (mbas *MessageBlsAggregatorService) getMessageBlsAggregationResponse(messag
 		}
 	}
 
+	sort.SliceStable(nonSignersOperatorIds, func(i, j int) bool {
+		a := new(big.Int).SetBytes(nonSignersOperatorIds[i][:])
+		b := new(big.Int).SetBytes(nonSignersOperatorIds[j][:])
+		return a.Cmp(b) == -1
+	})
+
+	nonSignersG1Pubkeys := []*bls.G1Point{}
+	for _, operatorId := range nonSignersOperatorIds {
+		operator := validationInfo.operatorsAvsStateDict[operatorId]
+		nonSignersG1Pubkeys = append(nonSignersG1Pubkeys, operator.OperatorInfo.Pubkeys.G1Pubkey)
+	}
+
 	indices, err := mbas.avsRegistryService.GetCheckSignaturesIndices(&bind.CallOpts{}, uint32(validationInfo.ethBlockNumber), validationInfo.quorumNumbers, nonSignersOperatorIds)
 	if err != nil {
 		mbas.logger.Error("Failed to get check signatures indices", "err", err)
@@ -500,7 +513,7 @@ func (mbas *MessageBlsAggregatorService) getMessageBlsAggregationResponse(messag
 		messages.MessageBlsAggregation{
 			EthBlockNumber:               uint64(validationInfo.ethBlockNumber),
 			MessageDigest:                messageDigest,
-			NonSignersPubkeysG1:          getG1PubkeysOfNonSigners(digestAggregatedOperators.signersOperatorIdsSet, validationInfo.operatorsAvsStateDict),
+			NonSignersPubkeysG1:          nonSignersG1Pubkeys,
 			QuorumApksG1:                 validationInfo.quorumApksG1,
 			SignersApkG2:                 digestAggregatedOperators.signersApkG2,
 			SignersAggSigG1:              digestAggregatedOperators.signersAggSigG1,
@@ -597,16 +610,6 @@ func checkIfFullStakeThresholdMet(
 		}
 	}
 	return true
-}
-
-func getG1PubkeysOfNonSigners(signersOperatorIdsSet map[eigentypes.OperatorId]bool, operatorAvsStateDict map[eigentypes.OperatorId]eigentypes.OperatorAvsState) []*bls.G1Point {
-	nonSignersG1Pubkeys := []*bls.G1Point{}
-	for operatorId, operator := range operatorAvsStateDict {
-		if _, operatorSigned := signersOperatorIdsSet[operatorId]; !operatorSigned {
-			nonSignersG1Pubkeys = append(nonSignersG1Pubkeys, operator.OperatorInfo.Pubkeys.G1Pubkey)
-		}
-	}
-	return nonSignersG1Pubkeys
 }
 
 func validateQuorumThresholdPercentages(quorumThresholdPercentages []eigentypes.QuorumThresholdPercentage) error {

--- a/aggregator/blsagg/message_blsagg.go
+++ b/aggregator/blsagg/message_blsagg.go
@@ -509,20 +509,18 @@ func (mbas *MessageBlsAggregatorService) getMessageBlsAggregationResponse(messag
 		}
 	}
 
-	aggregation, err := messages.StandardizeMessageBlsAggregation(
-		messages.MessageBlsAggregation{
-			EthBlockNumber:               uint64(validationInfo.ethBlockNumber),
-			MessageDigest:                messageDigest,
-			NonSignersPubkeysG1:          nonSignersG1Pubkeys,
-			QuorumApksG1:                 validationInfo.quorumApksG1,
-			SignersApkG2:                 digestAggregatedOperators.signersApkG2,
-			SignersAggSigG1:              digestAggregatedOperators.signersAggSigG1,
-			NonSignerQuorumBitmapIndices: indices.NonSignerQuorumBitmapIndices,
-			QuorumApkIndices:             indices.QuorumApkIndices,
-			TotalStakeIndices:            indices.TotalStakeIndices,
-			NonSignerStakeIndices:        indices.NonSignerStakeIndices,
-		},
-	)
+	aggregation := messages.MessageBlsAggregation{
+		EthBlockNumber:               uint64(validationInfo.ethBlockNumber),
+		MessageDigest:                messageDigest,
+		NonSignersPubkeysG1:          nonSignersG1Pubkeys,
+		QuorumApksG1:                 validationInfo.quorumApksG1,
+		SignersApkG2:                 digestAggregatedOperators.signersApkG2,
+		SignersAggSigG1:              digestAggregatedOperators.signersAggSigG1,
+		NonSignerQuorumBitmapIndices: indices.NonSignerQuorumBitmapIndices,
+		QuorumApkIndices:             indices.QuorumApkIndices,
+		TotalStakeIndices:            indices.TotalStakeIndices,
+		NonSignerStakeIndices:        indices.NonSignerStakeIndices,
+	}
 	if err != nil {
 		mbas.logger.Error("Failed to format aggregation", "err", err)
 		return MessageBlsAggregationServiceResponse{


### PR DESCRIPTION
## Current Behavior

`StandardizeMessageBlsAggregation` is not always sorting all non-signer-related slices based on the non-signer pubkey hash. The reason for that is the key slice was being used in the `sort.Slice` `less` to sort another slice, while it was not being sorted together.

## New Behavior

The method was removed, as it was not needed, and the ordering was guaranteed when building the object. Some small updates were also done in `MessageBlsAggregationService` to change the approach for getting non-signer pubkeys - it's now simpler and it's not necessary to assume any map behavior.

## Breaking Changes

None.

