### PR TITLE
Update nearcore to 2.2.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -522,7 +522,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "synstructure",
 ]
 
@@ -534,7 +534,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -627,7 +627,7 @@ dependencies = [
  "futures-lite 2.3.0",
  "parking",
  "polling 3.7.3",
- "rustix 0.38.34",
+ "rustix 0.38.36",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -684,7 +684,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -695,13 +695,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "aws-region"
-version = "0.25.4"
+version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fed2b9fca70f2908268d057a607f2a906f47edbf856ea8587de9038d264e22"
+checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
 dependencies = [
  "thiserror",
 ]
@@ -847,7 +847,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.7.4",
- "object 0.36.3",
+ "object 0.36.4",
  "rustc-demangle",
 ]
 
@@ -908,7 +908,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1072,10 +1072,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "syn_derive",
 ]
 
@@ -1208,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "jobserver",
  "libc",
@@ -1282,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1311,7 +1311,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1454,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -1687,7 +1687,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "subtle",
  "zeroize",
 ]
@@ -1700,7 +1700,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1724,7 +1724,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1735,7 +1735,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1820,7 +1820,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1841,7 +1841,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1852,7 +1852,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1864,8 +1864,8 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
- "syn 2.0.76",
+ "rustc_version 0.4.1",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1934,7 +1934,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2080,7 +2080,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2101,7 +2101,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2376,7 +2376,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2468,7 +2468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "stable_deref_trait",
 ]
 
@@ -2496,7 +2496,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2787,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -3165,7 +3165,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3196,7 +3196,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.34",
+ "rustix 0.38.36",
 ]
 
 [[package]]
@@ -3342,8 +3342,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "derive_more",
@@ -3362,26 +3362,26 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "near-cache"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "lru 0.12.4",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3427,8 +3427,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3452,8 +3452,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -3465,8 +3465,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "borsh 1.5.1",
@@ -3498,8 +3498,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3507,8 +3507,8 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3565,8 +3565,8 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "chrono",
@@ -3587,8 +3587,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3598,8 +3598,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "blake2",
  "borsh 1.5.1",
@@ -3623,8 +3623,8 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3643,8 +3643,8 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "borsh 1.5.1",
  "itertools 0.10.5",
@@ -3667,16 +3667,16 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "anyhow",
@@ -3703,8 +3703,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3713,8 +3713,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3745,8 +3745,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix-http",
  "awc",
@@ -3759,8 +3759,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3776,8 +3776,8 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -3787,8 +3787,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "anyhow",
@@ -3839,8 +3839,8 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "base64 0.21.7",
@@ -3865,8 +3865,8 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "borsh 1.5.1",
  "enum-map",
@@ -3882,8 +3882,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -3898,17 +3898,17 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "near-pool"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "borsh 1.5.1",
  "near-crypto",
@@ -3920,8 +3920,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -3963,8 +3963,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -3983,8 +3983,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4014,33 +4014,33 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "near-rpc-error-core",
  "serde",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "near-stdx"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 
 [[package]]
 name = "near-store"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4083,13 +4083,13 @@ dependencies = [
 
 [[package]]
 name = "near-structs-checker-core"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 
 [[package]]
 name = "near-structs-checker-lib"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "near-structs-checker-core",
  "near-structs-checker-macro",
@@ -4097,13 +4097,13 @@ dependencies = [
 
 [[package]]
 name = "near-structs-checker-macro"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 
 [[package]]
 name = "near-telemetry"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "awc",
@@ -4122,8 +4122,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "once_cell",
  "serde",
@@ -4133,8 +4133,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4149,8 +4149,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4170,8 +4170,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4185,7 +4185,7 @@ dependencies = [
  "region",
  "rkyv",
  "rustc-demangle",
- "rustix 0.38.34",
+ "rustix 0.38.36",
  "target-lexicon 0.12.16",
  "thiserror",
  "tracing",
@@ -4193,8 +4193,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "anyhow",
  "blst",
@@ -4223,7 +4223,7 @@ dependencies = [
  "prometheus",
  "pwasm-utils",
  "ripemd",
- "rustix 0.38.34",
+ "rustix 0.38.36",
  "serde",
  "serde_repr",
  "sha2",
@@ -4248,8 +4248,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "indexmap 1.9.3",
  "num-traits",
@@ -4259,8 +4259,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "backtrace",
  "cc",
@@ -4280,8 +4280,8 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4291,8 +4291,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4381,8 +4381,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0-rc.2"
+source = "git+https://github.com/near/nearcore?rev=1877e3dd2bf69908aa092e4d412eb417b8084c15#1877e3dd2bf69908aa092e4d412eb417b8084c15"
 dependencies = [
  "borsh 1.5.1",
  "near-crypto",
@@ -4526,15 +4526,15 @@ checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.5",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "memchr",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -4577,7 +4577,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4588,9 +4588,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.1+3.3.1"
+version = "300.3.2+3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
 dependencies = [
  "cc",
 ]
@@ -4970,7 +4970,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5070,7 +5070,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.34",
+ "rustix 0.38.36",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5103,7 +5103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5127,9 +5127,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
 ]
@@ -5202,7 +5202,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5244,7 +5244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b0e9b447d099ae2c4993c0cbb03c7a9d6c937b17f2d56cfc0b1550e6fcfdb76"
 dependencies = [
  "anyhow",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "log",
  "protobuf 3.5.1",
  "protobuf-support",
@@ -5264,9 +5264,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+checksum = "aa37f80ca58604976033fae9515a8a2989fc13797d953f7c04fb8fa36a11f205"
 dependencies = [
  "cc",
 ]
@@ -5739,9 +5739,9 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.23",
 ]
@@ -5771,9 +5771,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
  "bitflags 2.6.0",
  "errno 0.3.9",
@@ -5811,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.1.3",
@@ -5849,9 +5849,9 @@ checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -5993,9 +5993,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -6033,13 +6033,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6053,9 +6053,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -6071,7 +6071,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6096,7 +6096,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6113,7 +6113,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6122,7 +6122,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -6390,9 +6390,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6408,7 +6408,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6425,7 +6425,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6503,7 +6503,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.34",
+ "rustix 0.38.36",
  "windows-sys 0.59.0",
 ]
 
@@ -6524,7 +6524,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6604,9 +6604,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6649,7 +6649,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6690,9 +6690,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6701,9 +6701,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6729,11 +6729,11 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "toml_datetime",
  "winnow",
 ]
@@ -6829,7 +6829,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7063,7 +7063,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -7097,7 +7097,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7345,7 +7345,7 @@ version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "semver 1.0.23",
 ]
 
@@ -7370,7 +7370,7 @@ dependencies = [
  "bumpalo",
  "cfg-if 1.0.0",
  "fxprof-processed-profile",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "libc",
  "log",
  "object 0.32.2",
@@ -7449,7 +7449,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli 0.28.1",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "log",
  "object 0.32.2",
  "serde",
@@ -7475,7 +7475,7 @@ dependencies = [
  "log",
  "object 0.32.2",
  "rustc-demangle",
- "rustix 0.38.34",
+ "rustix 0.38.36",
  "serde",
  "serde_derive",
  "target-lexicon 0.12.16",
@@ -7515,7 +7515,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "libc",
  "log",
  "mach",
@@ -7523,7 +7523,7 @@ dependencies = [
  "memoffset 0.9.1",
  "paste",
  "rand",
- "rustix 0.38.34",
+ "rustix 0.38.36",
  "sptr",
  "wasm-encoder 0.35.0",
  "wasmtime-asm-macros",
@@ -7555,7 +7555,7 @@ checksum = "09b5575a75e711ca6c36bb9ad647c93541cdc8e34218031acba5da3f35919dd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7614,7 +7614,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.34",
+ "rustix 0.38.36",
 ]
 
 [[package]]
@@ -7804,9 +7804,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -7897,7 +7897,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7917,7 +7917,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -26,12 +26,12 @@ tracing = { version = "0.1.36", features = ["std"] }
 thiserror = "1.0.56"
 anyhow = "1.0.79"
 
-near-indexer = { git = "https://github.com/near/nearcore", rev = "d630c63d45bf2a98039ee15364af1717224e924a" }
-near-client = { git = "https://github.com/near/nearcore", rev = "d630c63d45bf2a98039ee15364af1717224e924a" }
-near-o11y = { git = "https://github.com/near/nearcore", rev = "d630c63d45bf2a98039ee15364af1717224e924a" }
-near-client-primitives = { git = "https://github.com/near/nearcore", rev = "d630c63d45bf2a98039ee15364af1717224e924a" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "1877e3dd2bf69908aa092e4d412eb417b8084c15" }
+near-client = { git = "https://github.com/near/nearcore", rev = "1877e3dd2bf69908aa092e4d412eb417b8084c15" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "1877e3dd2bf69908aa092e4d412eb417b8084c15" }
+near-client-primitives = { git = "https://github.com/near/nearcore", rev = "1877e3dd2bf69908aa092e4d412eb417b8084c15" }
 borsh = { version = "1.0.0", features = ["derive", "rc"] }
 serde_yaml = "0.9.34"
 
 [dev-dependencies]
-near-crypto = { git = "https://github.com/near/nearcore", rev = "d630c63d45bf2a98039ee15364af1717224e924a" }
+near-crypto = { git = "https://github.com/near/nearcore", rev = "1877e3dd2bf69908aa092e4d412eb417b8084c15" }


### PR DESCRIPTION
## Current Behavior

We're using nearcore 2.2.0-rc.1 in the indexer. NEAR issued a [new release](https://github.com/near/nearcore/releases/tag/2.2.0-rc.2) with `CODE_RED`, so we should transition to it as soon as possible.

## New Behavior

This updates the nearcore dependency to 2.2.0-rc.2

## Breaking Changes

None.

