### PR TITLE
Allow toggling monitoring in aggregator and relayer setups

### DIFF
--- a/setup/aggregator/docker-compose.yml
+++ b/setup/aggregator/docker-compose.yml
@@ -33,6 +33,7 @@ services:
         compress: "true"
 
   grafana:
+    profiles: ["monitoring"]
     image: grafana/grafana:9.4.1
     container_name: grafana
     volumes:
@@ -49,6 +50,7 @@ services:
       - "127.0.0.1:3000:3000"
 
   prometheus:
+    profiles: ["monitoring"]
     image: prom/prometheus:v2.42.0
     container_name: prometheus
     volumes:

--- a/setup/relayer/docker-compose.yml
+++ b/setup/relayer/docker-compose.yml
@@ -64,6 +64,7 @@ services:
         compress: "true"
 
   grafana:
+    profiles: ["monitoring"]
     image: grafana/grafana:9.4.1
     container_name: grafana
     volumes:
@@ -80,6 +81,7 @@ services:
       - "127.0.0.1:3001:3000"
 
   prometheus:
+    profiles: ["monitoring"]
     image: prom/prometheus:v2.42.0
     container_name: prometheus
     volumes:


### PR DESCRIPTION
## Current Behavior

Currently aggregator and relayer setups instantiate Grafana + Prometheus by default.

## New Behavior

This makes it so it's necessary to set the `monitoring` profile to instantiate those, so it's possible to toggle that by including the profile or not.

## Breaking Changes

None.

