### PR TITLE
Add rollup contracts anvil state generator script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,10 @@ deploy-eigenlayer-contracts-to-anvil-and-save-state: ## Deploy eigenlayer
 deploy-sffl-contracts-to-anvil-and-save-state: ## Deploy avs
 	./tests/anvil/deploy-avs-save-anvil-state.sh
 
-deploy-all-to-anvil-and-save-state: deploy-eigenlayer-contracts-to-anvil-and-save-state deploy-sffl-contracts-to-anvil-and-save-state ## deploy eigenlayer, shared avs contracts, and inc-sq contracts
+deploy-rollup-sffl-contracts-to-anvil-and-save-state: ## Deploy rollup contracts
+	./tests/anvil/deploy-rollup-avs-save-anvil-state.sh
+
+deploy-all-to-anvil-and-save-state: deploy-eigenlayer-contracts-to-anvil-and-save-state deploy-sffl-contracts-to-anvil-and-save-state deploy-rollup-sffl-contracts-to-anvil-and-save-state ## deploy eigenlayer and avs contracts
 
 start-anvil-chain-with-el-and-avs-deployed: ## starts anvil from a saved state file (with el and avs contracts deployed)
 	./tests/anvil/start-anvil-chain-with-el-and-avs-deployed.sh

--- a/tests/anvil/deploy-rollup-avs-save-anvil-state.sh
+++ b/tests/anvil/deploy-rollup-avs-save-anvil-state.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+RPC_URL=http://localhost:8545
+PRIVATE_KEY=0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$parent_path"
+
+anvil --dump-state data/rollup-avs-deployed-anvil-state.json &
+cd ../../contracts/evm
+forge script script/deploy/devnet/SFFLDeployerRollup.s.sol --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -v
+
+pkill anvil


### PR DESCRIPTION
## Current Behavior

We were already generating the rollup contracts anvil state manually for testing, but we didn't have a script for it.

## New Behavior

This adds a script similar to the AVS contracts one.

## Breaking Changes

None.

