### PR TITLE
Update registries to Nuffle Labs

### DIFF
--- a/setup/aggregator/docker-compose.yml
+++ b/setup/aggregator/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   near-sffl-aggregator:
-    image: ghcr.io/nethermindeth/near-sffl/aggregator:${SFFL_RELEASE}
+    image: ghcr.io/nuffle-labs/near-sffl/aggregator:${SFFL_RELEASE}
     container_name: near-sffl-aggregator
     volumes:
       - ./:/near-sffl/

--- a/setup/operator/docker-compose.yml
+++ b/setup/operator/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   near-sffl-indexer:
     profiles: [indexer]
-    image: ghcr.io/nethermindeth/near-sffl/indexer:${SFFL_RELEASE}
+    image: ghcr.io/nuffle-labs/near-sffl/indexer:${SFFL_RELEASE}
     container_name: near-sffl-indexer
     depends_on:
       rmq:
@@ -55,7 +55,7 @@ services:
 
   near-sffl-operator:
     profiles: [operator]
-    image: ghcr.io/nethermindeth/near-sffl/operator:${SFFL_RELEASE}
+    image: ghcr.io/nuffle-labs/near-sffl/operator:${SFFL_RELEASE}
     container_name: near-sffl-operator
     depends_on:
       rmq:

--- a/setup/plugin/register.sh
+++ b/setup/plugin/register.sh
@@ -11,4 +11,4 @@ docker run --rm \
   -v $(pwd):/near-sffl/ \
   --env-file .env \
   --pull=always \
-  ghcr.io/nethermindeth/near-sffl/operator-plugin:latest --config /near-sffl/config/operator.yaml --operation-type opt-in
+  ghcr.io/nuffle-labs/near-sffl/operator-plugin:latest --config /near-sffl/config/operator.yaml --operation-type opt-in

--- a/setup/relayer/docker-compose.yml
+++ b/setup/relayer/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   relayer_421614:
-    image: ghcr.io/nethermindeth/near-sffl/relayer:${SFFL_RELEASE}
+    image: ghcr.io/nuffle-labs/near-sffl/relayer:${SFFL_RELEASE}
     container_name: near-sffl-relayer-421614
     volumes:
       - ${NEAR_KEYS_DIR}:/root/.near-credentials
@@ -35,7 +35,7 @@ services:
         compress: "true"
 
   relayer_11155420:
-    image: ghcr.io/nethermindeth/near-sffl/relayer:${SFFL_RELEASE}
+    image: ghcr.io/nuffle-labs/near-sffl/relayer:${SFFL_RELEASE}
     container_name: near-sffl-relayer-11155420
     volumes:
       - ${NEAR_KEYS_DIR}:/root/.near-credentials


### PR DESCRIPTION
## Current Behavior

Currently, the docker images are all based on the `ghcr.io/nethermindeth/near-sffl` registry prefix.

## New Behavior

This changes the references to `ghcr.io/nuffle-labs/near-sffl` to target the moved repo.

## Breaking Changes

None.

## Observations

This will require asking the operators to update their local branches.

