### PR TITLE
Fix download config value not specified

### DIFF
--- a/indexer/entrypoint.sh
+++ b/indexer/entrypoint.sh
@@ -3,6 +3,6 @@
 if [ -z "$CHAIN_ID" ] || [ "$CHAIN_ID" = "localnet" ]; then
   /indexer-app/indexer init --chain-id localnet
 else
-  /indexer-app/indexer init --chain-id "$CHAIN_ID" --download-config --download-genesis
+  /indexer-app/indexer init --chain-id "$CHAIN_ID" --download-config rpc --download-genesis
 fi
 /indexer-app/indexer run "$@"


### PR DESCRIPTION
## Current Behavior

The `--download-config` option value is not specified. As per #296, this is necessary.

## New Behavior

Now it's set to `rpc`.

## Breaking Changes

None.

